### PR TITLE
Do not use Time#floor for keeping compatibility with Ruby 2.5 and Ruby 2.7

### DIFF
--- a/lib/ulid.rb
+++ b/lib/ulid.rb
@@ -89,7 +89,13 @@ class ULID
 
   # @return [Integer]
   def self.current_milliseconds
-    (Time.now.to_r * 1000).to_i
+    time_to_milliseconds(Time.now)
+  end
+
+  # @param [Time]
+  # @return [Integer]
+  def self.time_to_milliseconds(time)
+    (time.to_r * 1000).to_i
   end
 
   # @return [Integer]

--- a/test/test_ulid.rb
+++ b/test/test_ulid.rb
@@ -55,7 +55,7 @@ class TestULID < Test::Unit::TestCase
     assert_not_equal(ULID.generate, ULID.generate)
 
     time = Time.now
-    assert_equal(time.floor(3), ULID.generate(moment: time).to_time)
+    assert_equal(Time.at(0, ULID.time_to_milliseconds(time), :millisecond), ULID.generate(moment: time).to_time)
     milliseconds = 42
     assert_equal(Time.at(0, milliseconds, :millisecond), ULID.generate(moment: milliseconds).to_time)
 


### PR DESCRIPTION
Fixes #19