### PR TITLE
Revert to add `ULID#to_str` for `Range[ULID]`

### DIFF
--- a/lib/ulid.rb
+++ b/lib/ulid.rb
@@ -261,10 +261,9 @@ class ULID
   end
 
   # @return [String]
-  def to_str
+  def to_s
     @string ||= Integer::Base.string_for(to_i, ENCODING_CHARS).rjust(ENCODED_ID_LENGTH, '0').upcase.freeze
   end
-  alias_method :to_s, :to_str
 
   # @return [Integer]
   def to_i
@@ -279,7 +278,7 @@ class ULID
 
   # @return [String]
   def inspect
-    @inspect ||= "ULID(#{to_time.strftime(TIME_FORMAT_IN_INSPECT)}: #{to_str})".freeze
+    @inspect ||= "ULID(#{to_time.strftime(TIME_FORMAT_IN_INSPECT)}: #{to_s})".freeze
   end
 
   # @return [Boolean]
@@ -381,7 +380,7 @@ class ULID
 
   # @return [MatchData]
   def matchdata
-    @matchdata ||= STRICT_PATTERN.match(to_str).freeze
+    @matchdata ||= STRICT_PATTERN.match(to_s).freeze
   end
 end
 

--- a/sig/ulid.rbs
+++ b/sig/ulid.rbs
@@ -79,8 +79,7 @@ class ULID
   attr_reader milliseconds: Integer
   attr_reader entropy: Integer
   def initialize: (milliseconds: Integer, entropy: Integer) -> void
-  def to_str: -> String
-  alias to_s to_str
+  def to_s: -> String
   def to_i: -> Integer
   alias hash to_i
   def <=>: (ULID other) -> Integer

--- a/test/test_ulid.rb
+++ b/test/test_ulid.rb
@@ -382,12 +382,6 @@ class TestULID < Test::Unit::TestCase
     assert_equal(true, ulid.to_s.frozen?)
   end
 
-  def test_to_str
-    ulid = ULID.parse('01ARZ3NDEKTSV4RRFFQ69G5FAV')
-    assert_equal('01ARZ3NDEKTSV4RRFFQ69G5FAV', ulid.to_str)
-    assert_equal(Encoding::US_ASCII, ulid.to_str.encoding)
-  end
-
   def test_inspect
     ulid = ULID.parse('01ARZ3NDEKTSV4RRFFQ69G5FAV')
     assert_equal('ULID(2016-07-30 23:54:10.259 UTC: 01ARZ3NDEKTSV4RRFFQ69G5FAV)', ulid.inspect)
@@ -524,10 +518,6 @@ class TestFrozenULID < Test::Unit::TestCase
     @ulid.freeze
     @min = ULID.min.freeze
     @max = ULID.max.freeze
-  end
-
-  def test_to_str
-    assert_equal(@string, @ulid.to_str)
   end
 
   def test_inspect

--- a/test/test_ulid_usecase.rb
+++ b/test/test_ulid_usecase.rb
@@ -4,6 +4,28 @@
 require_relative 'helper'
 
 class TestULIDUseCase < Test::Unit::TestCase
+  def test_range_elements
+    begin_ulid = ULID.generate
+    ulid2 = begin_ulid.next
+    ulid3 = ulid2.next
+    ulid4 = ulid3.next
+    ulid5 = ulid4.next
+    end_ulid = ulid5.next
+
+    include_end = begin_ulid..end_ulid
+    exclude_end = begin_ulid...end_ulid
+
+    assert_equal([begin_ulid, ulid2, ulid3, ulid4, ulid5, end_ulid], include_end.each.to_a)
+    assert_equal([begin_ulid, ulid2, ulid3, ulid4, ulid5], exclude_end.each.to_a)
+
+    assert_equal([begin_ulid, ulid3, ulid5], include_end.step(2).to_a)
+    assert_equal([begin_ulid, ulid4], include_end.step(3).to_a)
+    assert_equal([begin_ulid, end_ulid], include_end.step(5).to_a)
+    assert_equal([begin_ulid, ulid3, ulid5], exclude_end.step(2).to_a)
+    assert_equal([begin_ulid, ulid4], exclude_end.step(3).to_a)
+    assert_equal([begin_ulid], exclude_end.step(5).to_a)
+  end
+
   # https://github.com/kachick/ruby-ulid/issues/47
   def test_filter_ulids_by_time
     time1_1 = Time.at(1, Rational('122999.999'))


### PR DESCRIPTION
Fixes #72
Reverts #14, Reverts 860ccb924e55a8852f912e56a95a44befafd0bee