### PR TITLE
Improve benchmarks for sorting

### DIFF
--- a/benchmark/sort.rb
+++ b/benchmark/sort.rb
@@ -1,31 +1,34 @@
 require 'benchmark/ips'
 require_relative '../lib/ulid'
 
-monotonic_generator = ULID::MonotonicGenerator.new
-ulid_objects = 10000.times.map do
-  monotonic_generator.generate
+frozen_ulid_objects = 10000.times.map do
+  ULID.generate.freeze
 end
-ulid_strings = ulid_objects.map(&:to_s)
-unless ulid_objects == ulid_objects.sort
-  raise 'Setup error'
-end
-
-unless ulid_strings == ulid_strings.sort
-  raise 'Setup error'
-end
-
-unless ulid_strings.sort == ulid_objects.sort.map(&:to_s)
-  raise 'Setup error'
-end
+ulid_strings = frozen_ulid_objects.map(&:to_s)
+non_cached_ulid_objects = frozen_ulid_objects.map(&:dup)
 
 Benchmark.ips do |x|
-  x.report('Sort in ULID object') do
-    ulid_objects.shuffle.sort
+  x.report('Sort ULID instance') do
+    non_cached_ulid_objects.shuffle.sort # After second sorting, cache will be work. So this benchmark is not accurate.
   end
 
-  x.report('Sort in String') do
+  x.report('Sort frozen ULID instance(some values cached)') do
+    frozen_ulid_objects.shuffle.sort
+  end
+
+  x.report('Sort by String encoded ULIDs') do
     ulid_strings.shuffle.sort
   end
 
   x.compare!
+end
+
+# I'll check to be sure sorting result is correct.
+
+unless ulid_strings == non_cached_ulid_objects.map(&:to_s)
+  raise 'Crucial Bug exists!'
+end
+
+unless ulid_strings == frozen_ulid_objects.map(&:to_s)
+  raise 'Crucial Bug exists!'
 end


### PR DESCRIPTION
```console
$ bundle exec ruby benchmark/sort.rb
Warming up --------------------------------------
  Sort ULID instance     3.000  i/100ms
Sort frozen ULID instance(some values cached)
                         3.000  i/100ms
Sort by String encoded ULIDs
                        18.000  i/100ms
Calculating -------------------------------------
  Sort ULID instance     37.261  (± 5.4%) i/s -    189.000  in   5.083937s
Sort frozen ULID instance(some values cached)
                         35.733  (± 5.6%) i/s -    180.000  in   5.062283s
Sort by String encoded ULIDs
                        187.953  (± 5.9%) i/s -    954.000  in   5.094077s

Comparison:
Sort by String encoded ULIDs:      188.0 i/s
  Sort ULID instance:       37.3 i/s - 5.04x  (± 0.00) slower
Sort frozen ULID instance(some values cached):       35.7 i/s - 5.26x  (± 0.00) slower
```