### PR TITLE
[RFC] Use `lexicographically sort` instead of integer

### DIFF
--- a/lib/ulid.rb
+++ b/lib/ulid.rb
@@ -282,7 +282,7 @@ class ULID
 
   # @return [Integer, nil]
   def <=>(other)
-    other.kind_of?(ULID) ? (to_i <=> other.to_i) : nil
+    other.kind_of?(ULID) ? (to_s <=> other.to_s) : nil
   end
 
   # @return [String]


### PR DESCRIPTION
Follow #80

```console
$ bundle exec ruby benchmark/sort.rb
Warming up --------------------------------------
  Sort ULID instance     2.000  i/100ms
Sort frozen ULID instance(some values cached)
                         2.000  i/100ms
Sort by String encoded ULIDs
                        12.000  i/100ms
Calculating -------------------------------------
  Sort ULID instance     25.516  (±11.8%) i/s -    126.000  in   5.022108s
Sort frozen ULID instance(some values cached)
                         22.438  (± 8.9%) i/s -    112.000  in   5.024219s
Sort by String encoded ULIDs
                        152.701  (±13.1%) i/s -    756.000  in   5.044429s

Comparison:
Sort by String encoded ULIDs:      152.7 i/s
  Sort ULID instance:       25.5 i/s - 5.98x  (± 0.00) slower
Sort frozen ULID instance(some values cached):       22.4 i/s - 6.81x  (± 0.00) slower
```

This change makes a bit faster rather than integer based sort 😮 

Hmm... but `to_i` might be optimized in #7...
But, the results are same in cached instance, so it does not change the result... 🤔 

We should go this way?
I think, then I should add more bench. (e.g `Range[ULID]#cover?`)
