### PR TITLE
Optimize `ULID.parse` and change exception type for upper `ULID.max`

### DIFF
--- a/benchmark/parse.rb
+++ b/benchmark/parse.rb
@@ -8,7 +8,13 @@ end
 raise 'Setup error' unless many_ulid_strings.uniq.size == 10000
 
 Benchmark.ips do |x|
-  x.report('ULID.parse') do
+  x.report('ULID.parse_with_integer_base / Before #7') do
+    ULID.parse_with_integer_base(many_ulid_strings.sample)
+  end
+
+  x.report('ULID.parse / After #7') do
     ULID.parse(many_ulid_strings.sample)
   end
+
+  x.compare!
 end

--- a/sig/ulid.rbs
+++ b/sig/ulid.rbs
@@ -15,6 +15,8 @@ class ULID
   PATTERN: Regexp
   STRICT_PATTERN: Regexp
   UUIDV4_PATTERN: Regexp
+  REPLACING_MAP: Hash[String, String]
+  REPLACING_PATTERN: Regexp
   MONOTONIC_GENERATOR: MonotonicGenerator
   MIN: ULID
   MAX: ULID
@@ -30,6 +32,9 @@ class ULID
   end
 
   class ParserError < Error
+  end
+
+  class SetupError < ScriptError
   end
 
   class MonotonicGenerator
@@ -80,6 +85,7 @@ class ULID
                 | (String string) { (ULID ulid) -> void } -> singleton(ULID)
   def self.octets_from_integer: (Integer integer, length: Integer) -> Array[Integer]
   def self.inverse_of_digits: (Array[Integer] reversed_digits) -> Integer
+  def self.convert_crockford_base32_to_n32: (String) -> String
   attr_reader milliseconds: Integer
   attr_reader entropy: Integer
   def initialize: (milliseconds: Integer, entropy: Integer) -> void

--- a/test/test_many_data.rb
+++ b/test/test_many_data.rb
@@ -17,4 +17,11 @@ class TestManyData < Test::Unit::TestCase
     assert_equal(true, (5..50).cover?(ulids.group_by(&:to_time).size))
     assert_not_equal(ulids, ulids.sort_by(&:to_s))
   end
+
+  def test_parse_reversible
+    10000.times do
+      ulid_string = ULID.from_integer(SecureRandom.random_number(ULID::MAX_INTEGER)).to_s
+      assert_equal(ulid_string, ULID.parse(ulid_string).to_s)
+    end
+  end
 end

--- a/test/test_ulid.rb
+++ b/test/test_ulid.rb
@@ -50,8 +50,7 @@ class TestULID < Test::Unit::TestCase
     err = assert_raises(ULID::ParserError) do
       ULID.parse('01ARZ3NDEKTSV4RRFFQ69G5FA')
     end
-
-    assert_match(/parsing failure as.+parsable string must be 26 characters, but actually given 25 characters.+01ARZ3NDEKTSV4RRFFQ69G5FA/, err.message)
+    assert_match(/given argument does not match to/, err.message)
   end
 
   def test_new
@@ -296,12 +295,6 @@ class TestULID < Test::Unit::TestCase
     assert_equal(true, ulid.strict_pattern.match?(ulid.to_s.downcase))
     assert_equal(false, ulid.strict_pattern.match?(ulid.next.to_s))
     assert_equal({'timestamp' => '01ARZ3NDEK', 'randomness' => 'TSV4RRFFQ69G5FAV'}, ulid.strict_pattern.match(ulid.to_s).named_captures)
-  end
-
-  def test_overflow
-    assert_raises(ULID::OverflowError) do
-      ULID.parse('80000000000000000000000000')
-    end
   end
 
   def test_generate

--- a/test/test_ulid.rb
+++ b/test/test_ulid.rb
@@ -19,10 +19,17 @@ class TestULID < Test::Unit::TestCase
   end
 
   def test_parse
-    parsed = ULID.parse('01ARZ3NDEKTSV4RRFFQ69G5FAV')
+    string = +'01ARZ3NDEKTSV4RRFFQ69G5FAV'
+    dup_string = string.dup
+    parsed = ULID.parse(string)
+
+    # Ensure the string is not modified in parser
+    assert_equal(false, string.frozen?)
+    assert_equal(dup_string, string)
+
     assert_instance_of(ULID, parsed)
-    assert_equal('01ARZ3NDEKTSV4RRFFQ69G5FAV', parsed.to_s)
-    assert_equal('01ARZ3NDEKTSV4RRFFQ69G5FAV', ULID.parse('01ARZ3NDEKTSV4RRFFQ69G5FAV'.downcase).to_s)
+    assert_equal(string, parsed.to_s)
+    assert_equal(string, ULID.parse(string.downcase).to_s)
 
     assert_raises(ULID::ParserError) do
       ULID.parse(nil)

--- a/test/test_ulid_example_values.rb
+++ b/test/test_ulid_example_values.rb
@@ -18,14 +18,14 @@ class TestULIDWithExampleValues < Test::Unit::TestCase
     assert_instance_of(ULID, ULID.parse('00000000000000000000000000'))
     assert_instance_of(ULID, ULID.parse('70000000000000000000000000'))
     assert_instance_of(ULID, ULID.parse('7ZZZZZZZZZZZZZZZZZZZZZZZZZ'))
-    # Might be change to ULID::ParserError in this library ref: https://github.com/kachick/ruby-ulid/issues/45
-    assert_raises(ULID::OverflowError) do
+    # Changed to ULID::ParserError in this library ref: https://github.com/kachick/ruby-ulid/issues/45
+    assert_raises(ULID::ParserError) do
       ULID.parse('80000000000000000000000000')
     end
-    assert_raises(ULID::OverflowError) do
+    assert_raises(ULID::ParserError) do
       ULID.parse('80000000000000000000000001')
     end
-    assert_raises(ULID::OverflowError) do
+    assert_raises(ULID::ParserError) do
       ULID.parse('ZZZZZZZZZZZZZZZZZZZZZZZZZZ')
     end
 


### PR DESCRIPTION
For a parser part of #7

```console
$ ruby -v
ruby 3.0.1p64 (2021-04-05 revision 0fb782ee38) [x86_64-darwin20]

$ bundle exec ruby benchmark/parse.rb
Warming up --------------------------------------
ULID.parse_with_integer_base / Before #7
                         1.103k i/100ms
ULID.parse / After #7
                        13.064k i/100ms
Calculating -------------------------------------
ULID.parse_with_integer_base / Before #7
                         12.282k (± 4.2%) i/s -     61.768k in   5.037999s
ULID.parse / After #7
                        129.000k (± 3.1%) i/s -    653.200k in   5.068698s

Comparison:
ULID.parse / After #7:   128999.6 i/s
ULID.parse_with_integer_base / Before #7:    12282.2 i/s - 10.50x  (± 0.00) slower
```

And closes #45