### PR TITLE
Optimize `ULID#to_s` with using native `Integer#to_s`

### DIFF
--- a/benchmark/generate.rb
+++ b/benchmark/generate.rb
@@ -1,3 +1,6 @@
+# coding: utf-8
+# frozen_string_literal: true
+
 require 'benchmark/ips'
 require_relative '../lib/ulid'
 

--- a/benchmark/parse.rb
+++ b/benchmark/parse.rb
@@ -1,3 +1,6 @@
+# coding: utf-8
+# frozen_string_literal: true
+
 require 'benchmark/ips'
 require_relative '../lib/ulid'
 

--- a/benchmark/sort.rb
+++ b/benchmark/sort.rb
@@ -1,3 +1,6 @@
+# coding: utf-8
+# frozen_string_literal: true
+
 require 'benchmark/ips'
 require_relative '../lib/ulid'
 

--- a/benchmark/to_s.rb
+++ b/benchmark/to_s.rb
@@ -1,23 +1,12 @@
+# coding: utf-8
+# frozen_string_literal: true
+
 require 'benchmark/ips'
 require_relative '../lib/ulid'
 
-ulid = ULID.generate
-ulid.to_s # Cached the result
-
-many_ulids = 1000000.times.map do
-  ULID.generate
-end
-
 Benchmark.ips do |x|
-  x.report('ULID#to_s first time, having some overhead from taking the object pool') do
-    if non_cached_ulid = many_ulids.pop
-      non_cached_ulid.to_s
-    else
-      raise 'shortage ulid pool'
-    end
-  end
-
-  x.report('ULID#to_s multiple times makes faster') { ulid.to_s }
+  x.report('ULID#to_s_with_integer_base / Before #7') { ULID.generate.to_s_with_integer_base }
+  x.report('ULID#to_s / After #7') { ULID.generate.to_s }
 
   x.compare!
 end

--- a/sig/ulid.rbs
+++ b/sig/ulid.rbs
@@ -15,8 +15,10 @@ class ULID
   PATTERN: Regexp
   STRICT_PATTERN: Regexp
   UUIDV4_PATTERN: Regexp
-  REPLACING_MAP: Hash[String, String]
-  REPLACING_PATTERN: Regexp
+  N32_CHAR_BY_CROCKFORD_BASE32_CHAR: Hash[String, String]
+  CROCKFORD_BASE32_CHAR_PATTERN: Regexp
+  CROCKFORD_BASE32_CHAR_BY_N32_CHAR: Hash[String, String]
+  N32_CHAR_PATTERN: Regexp
   MONOTONIC_GENERATOR: MonotonicGenerator
   MIN: ULID
   MAX: ULID
@@ -85,7 +87,6 @@ class ULID
                 | (String string) { (ULID ulid) -> void } -> singleton(ULID)
   def self.octets_from_integer: (Integer integer, length: Integer) -> Array[Integer]
   def self.inverse_of_digits: (Array[Integer] reversed_digits) -> Integer
-  def self.convert_crockford_base32_to_n32: (String) -> String
   attr_reader milliseconds: Integer
   attr_reader entropy: Integer
   def initialize: (milliseconds: Integer, entropy: Integer) -> void
@@ -113,7 +114,9 @@ class ULID
   def freeze: -> self
 
   private
+  def self.convert_crockford_base32_to_n32: (String) -> String
   def self.argument_error_for_range_building: (untyped argument) -> ArgumentError
+  def convert_n32_to_crockford_base32: (String) -> String
   def matchdata: -> MatchData
   def cache_all_instance_variables: -> void
 end


### PR DESCRIPTION
For a decoder part of #7

Same direction as 8ccb012fe6e0cf7664535595879aa38b50f6763f, #85

```console
$ ruby -v
ruby 3.0.1p64 (2021-04-05 revision 0fb782ee38) [x86_64-darwin20]

$ bundle exec ruby benchmark/to_s.rb
Warming up --------------------------------------
ULID#to_s_with_integer_base / Before #7
                         2.228k i/100ms
ULID#to_s / After #7     5.882k i/100ms
Calculating -------------------------------------
ULID#to_s_with_integer_base / Before #7
                         23.567k (± 9.4%) i/s -    118.084k in   5.056627s
ULID#to_s / After #7     74.358k (± 5.6%) i/s -    376.448k in   5.079996s

Comparison:
ULID#to_s / After #7:    74357.6 i/s
ULID#to_s_with_integer_base / Before #7:    23567.4 i/s - 3.16x  (± 0.00) slower
```

ref: #86, #88