### PR TITLE
Drop deprecated `ULID.monotonic_generate`

### DIFF
--- a/lib/ulid.rb
+++ b/lib/ulid.rb
@@ -61,20 +61,6 @@ class ULID
     MAX_MILLISECONDS.equal?(moment) ? MAX : generate(moment: moment, entropy: MAX_ENTROPY)
   end
 
-  # @deprecated This method actually changes class state. Use {ULID::MonotonicGenerator} instead.
-  # @raise [OverflowError] if the entropy part is larger than the ULID limit in same milliseconds
-  # @return [ULID]
-  def self.monotonic_generate
-    warning = "`ULID.monotonic_generate` actually changes class state. Use `ULID::MonotonicGenerator` instead."
-    if RUBY_VERSION >= '3.0'
-      Warning.warn(warning, category: :deprecated)
-    else
-      Warning.warn(warning)
-    end
-
-    MONOTONIC_GENERATOR.generate
-  end
-
   # @param [String, #to_str] string
   # @return [Enumerator]
   # @yieldparam [ULID] ulid
@@ -169,23 +155,27 @@ class ULID
     end
   end
 
+  # @api private
   # @return [Integer]
   def self.current_milliseconds
     milliseconds_from_time(Time.now)
   end
 
+  # @api private
   # @param [Time] time
   # @return [Integer]
   def self.milliseconds_from_time(time)
     (time.to_r * 1000).to_i
   end
 
+  # @api private
   # @param [Time, Integer] moment
   # @return [Integer]
   def self.milliseconds_from_moment(moment)
     moment.kind_of?(Time) ? milliseconds_from_time(moment) : moment.to_int
   end
 
+  # @api private
   # @return [Integer]
   def self.reasonable_entropy
     SecureRandom.random_number(MAX_ENTROPY)
@@ -500,7 +490,6 @@ require_relative 'ulid/monotonic_generator'
 class ULID
   MIN = parse('00000000000000000000000000').freeze
   MAX = parse('7ZZZZZZZZZZZZZZZZZZZZZZZZZ').freeze
-  MONOTONIC_GENERATOR = MonotonicGenerator.new
 
   private_constant :ENCODING_CHARS, :TIME_FORMAT_IN_INSPECT, :UUIDV4_PATTERN, :MIN, :MAX, :CROCKFORD_BASE32_CHAR_PATTERN, :N32_CHAR_BY_CROCKFORD_BASE32_CHAR, :CROCKFORD_BASE32_CHAR_BY_N32_CHAR, :N32_CHAR_PATTERN
 end

--- a/sig/ulid.rbs
+++ b/sig/ulid.rbs
@@ -19,7 +19,6 @@ class ULID
   CROCKFORD_BASE32_CHAR_PATTERN: Regexp
   CROCKFORD_BASE32_CHAR_BY_N32_CHAR: Hash[String, String]
   N32_CHAR_PATTERN: Regexp
-  MONOTONIC_GENERATOR: MonotonicGenerator
   MIN: ULID
   MAX: ULID
   include Comparable

--- a/test/test_ulid_monotonic_generator.rb
+++ b/test/test_ulid_monotonic_generator.rb
@@ -12,7 +12,15 @@ class TestULIDMonotonicGenerator < Test::Unit::TestCase
     assert_not_same(ULID::MonotonicGenerator.new, ULID::MonotonicGenerator.new)
   end
 
-  def test_bigdata
+  def test_interface
+    assert_instance_of(ULID::MonotonicGenerator, @generator)
+    assert_not_equal(@generator.generate, @generator.generate)
+    first = @generator.generate
+    second = @generator.generate
+    assert_equal(true, second > first)
+  end
+
+  def test_many_data
     ulids = 1000.times.map do |n|
       if (n % 100).zero?
         sleep(0.01)
@@ -94,54 +102,12 @@ class TestULIDMonotonicGenerator < Test::Unit::TestCase
       @generator.generate(moment: max_ulid_in_a_milliseconds.milliseconds)
     end
   end
-end
-
-class TestULIDMonotonicGeneratorOfClassState < Test::Unit::TestCase
-  def test_interface
-    assert_instance_of(ULID, ULID.monotonic_generate)
-    assert_not_equal(ULID.monotonic_generate, ULID.monotonic_generate)
-    first = ULID.monotonic_generate
-    second = ULID.monotonic_generate
-    assert_equal(true, second > first)
-  end
-
-  def test_bigdata
-    ulids = 1000.times.map do |n|
-      if (n % 100).zero?
-        sleep(0.01)
-      end
-
-      ULID.monotonic_generate
-    end
-
-    assert_equal(1000, ulids.map(&:to_s).uniq.size)
-    assert_equal(true, (5..50).cover?(ulids.group_by(&:to_time).size))
-    assert_equal(ulids, ulids.sort_by(&:to_s))
-    assert_equal(ulids, ulids.sort_by(&:to_i))
-    assert_equal(ulids, ulids.sort)
-  end
 
   def test_freeze
     assert_raises(TypeError) do
-      ULID::MONOTONIC_GENERATOR.freeze
+      @generator.freeze
     end
 
-    assert_equal(false, ULID::MONOTONIC_GENERATOR.frozen?)
-  end
-
-  def test_attributes
-    id = BasicObject.new # Invalid value for the actual use-case, just for test
-    assert_equal(0, ULID::MONOTONIC_GENERATOR.latest_milliseconds)
-    assert_equal(false, [nil, 0, 1, ULID::MAX_ENTROPY].include?(ULID::MONOTONIC_GENERATOR.latest_entropy))
-
-    ULID::MONOTONIC_GENERATOR.latest_milliseconds = id
-    ULID::MONOTONIC_GENERATOR.latest_entropy = id
-
-    assert_same(id, ULID::MONOTONIC_GENERATOR.latest_milliseconds)
-    assert_same(id, ULID::MONOTONIC_GENERATOR.latest_entropy)
-  end
-
-  def teardown
-    ULID::MONOTONIC_GENERATOR.reset
+    assert_equal(false, @generator.frozen?)
   end
 end


### PR DESCRIPTION
And clarify some util methods are private api with YARD tag

Follow #32

ref: #88