### PR TITLE
Add tests and benchmarks for `ULID#octets` `ULID#timestamp_octets` `ULID#randomness_octets`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -48,6 +48,7 @@ task :benchmark do
   sh 'bundle exec ruby benchmark/generate.rb'
   sh 'bundle exec ruby benchmark/parse.rb'
   sh 'bundle exec ruby benchmark/core_instance_methods.rb'
+  sh 'bundle exec ruby benchmark/extra_instance_methods.rb'
   sh 'bundle exec ruby benchmark/sort.rb'
 end
 

--- a/benchmark/extra_instance_methods.rb
+++ b/benchmark/extra_instance_methods.rb
@@ -1,0 +1,13 @@
+# coding: utf-8
+# frozen_string_literal: true
+
+require 'benchmark/ips'
+require_relative '../lib/ulid'
+
+Benchmark.ips do |x|
+  x.report('ULID#octets') { ULID.sample.octets }
+  x.report('ULID#timestamp_octets') { ULID.sample.timestamp_octets }
+  x.report('ULID#randomness_octets') { ULID.sample.randomness_octets }
+
+  x.compare!
+end

--- a/test/many_data/test_randomized_many_data.rb
+++ b/test/many_data/test_randomized_many_data.rb
@@ -35,4 +35,28 @@ class TestManyData < Test::Unit::TestCase
     assert_equal(ulids.size, ulids.group_by(&:timestamp).size)
     assert_equal(ulids.size, ulids.group_by(&:randomness).size)
   end
+
+  def test_octets
+    ULID.sample(10000).each do |ulid|
+      assert_instance_of(Array, ulid.octets)
+      assert(ulid.octets.all?(Integer))
+      assert_equal(ULID::OCTETS_LENGTH, ulid.octets.size)
+      assert_same(ulid.octets, ulid.octets)
+      assert(ulid.octets.frozen?)
+
+      assert_instance_of(Array, ulid.timestamp_octets)
+      assert(ulid.timestamp_octets.all?(Integer))
+      assert_equal(ULID::TIMESTAMP_OCTETS_LENGTH, ulid.timestamp_octets.size)
+      assert_same(ulid.timestamp_octets, ulid.timestamp_octets)
+      assert(ulid.timestamp_octets.frozen?)
+
+      assert_instance_of(Array, ulid.randomness_octets)
+      assert(ulid.randomness_octets.all?(Integer))
+      assert_equal(ULID::RANDOMNESS_OCTETS_LENGTH, ulid.randomness_octets.size)
+      assert_same(ulid.randomness_octets, ulid.randomness_octets)
+      assert(ulid.randomness_octets.frozen?)
+
+      assert_equal(ulid.octets, ulid.timestamp_octets + ulid.randomness_octets)
+    end
+  end
 end


### PR DESCRIPTION
For a preparation part of #13
I'll create refactoring in another PR

Before
---

```console
$ ruby -v
ruby 3.0.1p64 (2021-04-05 revision 0fb782ee38) [x86_64-darwin20]

$ bundle exec ruby benchmark/extra_instance_methods.rb
Warming up --------------------------------------
         ULID#octets    13.737k i/100ms
ULID#timestamp_octets
                        16.468k i/100ms
ULID#randomness_octets
                        15.202k i/100ms
Calculating -------------------------------------
         ULID#octets    139.617k (± 3.3%) i/s -    700.587k in   5.023420s
ULID#timestamp_octets
                        164.179k (± 6.9%) i/s -    823.400k in   5.042092s
ULID#randomness_octets
                        137.516k (± 7.4%) i/s -    684.090k in   5.002423s

Comparison:
ULID#timestamp_octets:   164179.5 i/s
         ULID#octets:   139617.3 i/s - 1.18x  (± 0.00) slower
ULID#randomness_octets:   137516.2 i/s - 1.19x  (± 0.00) slower
```