### PR TITLE
Optimize `ULID.from_integer`

### DIFF
--- a/sig/ulid.rbs
+++ b/sig/ulid.rbs
@@ -87,7 +87,7 @@ class ULID
   def self.from_monotonic_generator: (MonotonicGenerator generator) -> ULID
   attr_reader milliseconds: Integer
   attr_reader entropy: Integer
-  def initialize: (milliseconds: Integer, entropy: Integer) -> void
+  def initialize: (milliseconds: Integer, entropy: Integer, ?integer: Integer) -> void
   def to_s: -> String
   def to_i: -> Integer
   alias hash to_i


### PR DESCRIPTION
Resolves #100

Before
---

```console
$ ruby -v
ruby 3.0.1p64 (2021-04-05 revision 0fb782ee38) [x86_64-darwin20]

$ bundle exec ruby benchmark/generate.rb
Warming up --------------------------------------
       ULID.generate    43.592k i/100ms
ULID::MonotonicGenerator#generate
                        55.592k i/100ms
ULID.from_integer with random value
                        19.582k i/100ms
ULID.from_integer with fixed integer `223672915396751631478612715538188246313` (To compare randomizing over
head)                                                                                                                              21.674k i/100ms
ULID.min with no arguments is optimized
                         1.132M i/100ms
ULID.max with no arguments is optimized
                       896.613k i/100ms
         ULID.sample    19.374k i/100ms
             ULID.at    42.812k i/100ms
Calculating -------------------------------------
       ULID.generate    420.359k (± 7.4%) i/s -      2.136M in   5.117387s
ULID::MonotonicGenerator#generate
                        507.860k (± 5.2%) i/s -      2.557M in   5.049530s
ULID.from_integer with random value
                        174.525k (± 8.4%) i/s -    881.190k in   5.087632s
ULID.from_integer with fixed integer `223672915396751631478612715538188246313` (To compare randomizing over
head)
                        205.885k (± 3.7%) i/s -      1.040M in   5.059897s
ULID.min with no arguments is optimized
                         10.650M (± 4.1%) i/s -     53.195M in   5.003190s
ULID.max with no arguments is optimized
                          8.391M (± 4.0%) i/s -     42.141M in   5.030290s
         ULID.sample    177.578k (± 4.1%) i/s -    891.204k in   5.027161s
             ULID.at    375.777k (±10.0%) i/s -      1.884M in   5.063203s

Comparison:
ULID.min with no arguments is optimized: 10649746.1 i/s
ULID.max with no arguments is optimized:  8391063.1 i/s - 1.27x  (± 0.00) slower
ULID::MonotonicGenerator#generate:   507860.4 i/s - 20.97x  (± 0.00) slower
       ULID.generate:   420359.1 i/s - 25.33x  (± 0.00) slower
             ULID.at:   375776.6 i/s - 28.34x  (± 0.00) slower
ULID.from_integer with fixed integer `223672915396751631478612715538188246313` (To compare randomizing over
head):   205884.8 i/s - 51.73x  (± 0.00) slower
         ULID.sample:   177577.5 i/s - 59.97x  (± 0.00) slower
ULID.from_integer with random value:   174525.3 i/s - 61.02x  (± 0.00) slower
```

After
---

```console
$ ruby -v
ruby 3.0.1p64 (2021-04-05 revision 0fb782ee38) [x86_64-darwin20]

$ bundle exec ruby benchmark/generate.rb
Warming up --------------------------------------
       ULID.generate    34.578k i/100ms
ULID::MonotonicGenerator#generate
                        48.055k i/100ms
ULID.from_integer with random value
                        43.651k i/100ms
ULID.from_integer with fixed integer `306137966476997400524319023589388144452` (To compare randomizing over
head)
                        56.027k i/100ms
ULID.min with no arguments is optimized
                         1.063M i/100ms
ULID.max with no arguments is optimized
                       936.128k i/100ms
         ULID.sample    37.933k i/100ms
             ULID.at    42.593k i/100ms
Calculating -------------------------------------
       ULID.generate    404.167k (± 3.2%) i/s -      2.040M in   5.052922s
ULID::MonotonicGenerator#generate
                        467.837k (± 3.6%) i/s -      2.355M in   5.039806s
ULID.from_integer with random value
                        367.149k (± 8.4%) i/s -      1.833M in   5.028136s
ULID.from_integer with fixed integer `306137966476997400524319023589388144452` (To compare randomizing over
head)
                        557.304k (± 4.2%) i/s -      2.801M in   5.035457s
ULID.min with no arguments is optimized
                         11.013M (± 5.0%) i/s -     55.252M in   5.029629s
ULID.max with no arguments is optimized
                          8.899M (± 3.6%) i/s -     44.934M in   5.056422s
         ULID.sample    395.298k (± 3.8%) i/s -      2.010M in   5.093498s
             ULID.at    417.408k (± 3.4%) i/s -      2.087M in   5.005865s

Comparison:
ULID.min with no arguments is optimized: 11012981.6 i/s
ULID.max with no arguments is optimized:  8898588.4 i/s - 1.24x  (± 0.00) slower
ULID.from_integer with fixed integer `306137966476997400524319023589388144452` (To compare randomizing over
head):   557303.7 i/s - 19.76x  (± 0.00) slower
ULID::MonotonicGenerator#generate:   467837.3 i/s - 23.54x  (± 0.00) slower
             ULID.at:   417408.0 i/s - 26.38x  (± 0.00) slower
       ULID.generate:   404167.2 i/s - 27.25x  (± 0.00) slower
         ULID.sample:   395298.4 i/s - 27.86x  (± 0.00) slower
ULID.from_integer with random value:   367148.9 i/s - 30.00x  (± 0.00) slower
```

Conclusion
---

>2x slower than ULID.generate

Now it is almost the same. And `ULID.from_integer` cached the given `integer`. So better than other constructors for now.

```
irb(main):001:0> measure
TIME is added.
irb(main):004:0> 100000.times{ ULID.generate.to_s }; nil
processing time: 1.409930s
irb(main):005:0> 100000.times{ ULID.sample.to_s }; nil
processing time: 0.999433s
```

`ULID.sample` is using `ULID.from_integer`. So it makes faster `ULID#to_s`.