### PR TITLE
Refactor `ULID.parse` with optimized `ULID.from_integer`

### DIFF
--- a/lib/ulid.rb
+++ b/lib/ulid.rb
@@ -267,12 +267,7 @@ class ULID
     end
 
     n32encoded = string.upcase.gsub(CROCKFORD_BASE32_CHAR_PATTERN, N32_CHAR_BY_CROCKFORD_BASE32_CHAR)
-    timestamp = n32encoded.slice(0, TIMESTAMP_ENCODED_LENGTH)
-    randomness = n32encoded.slice(TIMESTAMP_ENCODED_LENGTH, RANDOMNESS_ENCODED_LENGTH)
-    milliseconds = timestamp.to_i(32)
-    entropy = randomness.to_i(32)
-
-    new milliseconds: milliseconds, entropy: entropy
+    from_integer(n32encoded.to_i(32))
   end
 
   # @return [Boolean]


### PR DESCRIPTION
```
Warming up --------------------------------------
ULID.parse / After #7
                        12.036k i/100ms
ULID.parse2 / After #114
                        10.359k i/100ms
Calculating -------------------------------------
ULID.parse / After #7
                        112.137k (± 9.4%) i/s -    565.692k in   5.094086s
ULID.parse2 / After #114
                        104.315k (± 6.5%) i/s -    528.309k in   5.085027s

Comparison:
ULID.parse / After #7:   112136.8 i/s
ULID.parse2 / After #114:   104315.1 i/s - same-ish: difference falls within error
```

The result looks same, but it makes actually faster for use-cases, because `from_integer` cached the integer. ref: #112