### PR TITLE
Optimize `ULID.valid?`

### DIFF
--- a/lib/ulid.rb
+++ b/lib/ulid.rb
@@ -222,13 +222,11 @@ class ULID
     from_integer(CrockfordBase32.decode(string))
   end
 
+  # @param [String, #to_str] string
   # @return [Boolean]
   def self.valid?(string)
-    parse(string)
-  rescue Exception
-    false
-  else
-    true
+    string = String.try_convert(string)
+    string ? STRICT_PATTERN.match?(string) : false
   end
 
   # @api private

--- a/test/many_data/test_fixed_many_data.rb
+++ b/test/many_data/test_fixed_many_data.rb
@@ -19,6 +19,7 @@ class TestFixedManyData < Test::Unit::TestCase
     assert_equal(example.uuidv4, ulid.to_uuidv4)
     assert_equal(example.to_time, ulid.to_time)
     assert_equal(ULID.floor(example.time), ulid.to_time)
+    assert_equal(true, ULID.valid?(example.string))
   end
 
   def test_many_fixed_examples_for_from_integer

--- a/test/test_ulid_class.rb
+++ b/test/test_ulid_class.rb
@@ -93,12 +93,21 @@ class TestULIDClass < Test::Unit::TestCase
   def test_valid?
     assert_equal(false, ULID.valid?(nil))
     assert_equal(false, ULID.valid?(''))
+    assert_equal(false, ULID.valid?(BasicObject.new))
+    assert_equal(false, ULID.valid?(Object.new))
+    assert_equal(false, ULID.valid?(42))
+    assert_equal(false, ULID.valid?(:'01ARZ3NDEKTSV4RRFFQ69G5FAV'))
+    assert_equal(false, ULID.valid?(ULID.sample))
     assert_equal(false, ULID.valid?("01ARZ3NDEKTSV4RRFFQ69G5FAV\n"))
     assert_equal(false, ULID.valid?('01ARZ3NDEKTSV4RRFFQ69G5FAU'))
     assert_equal(true, ULID.valid?('01ARZ3NDEKTSV4RRFFQ69G5FAV'))
     assert_equal(true, ULID.valid?('01ARZ3NDEKTSV4RRFFQ69G5FAV'.downcase))
     assert_equal(true, ULID.valid?('7ZZZZZZZZZZZZZZZZZZZZZZZZZ'))
     assert_equal(false, ULID.valid?('80000000000000000000000000'))
+
+    assert_raises(ArgumentError) do
+      ULID.valid?
+    end
   end
 
   def test_range


### PR DESCRIPTION
I have checked with simple bench as below.

```
irb(main):001:0> measure
TIME is added.
irb(main):003:0> ULID.sample(100000).each { |ulid| ULID.valid_old?(ulid.to_s) }; nil
processing time: 2.306642s
irb(main):004:0> ULID.sample(100000).each { |ulid| ULID.valid?(ulid.to_s) }; nil
processing time: 1.359501s
```