### PR TITLE
Make `ULID::MonotonicGenerator` as Thread-safe

### DIFF
--- a/test/test_ulid_monotonic_generator_thread_safety.rb
+++ b/test/test_ulid_monotonic_generator_thread_safety.rb
@@ -1,0 +1,38 @@
+# coding: utf-8
+# frozen_string_literal: true
+
+require_relative 'helper'
+
+class TestULIDMonotonicGeneratorThreadSafety < Test::Unit::TestCase
+  def test_thread_safe
+    generator = ULID::MonotonicGenerator.new
+    thread_count = 5000
+    moment = ULID.parse('01ARZ3NDEKTSV4RRFFQ69G5FAV').to_time
+
+    ulids = []
+    worked_thread_numbers = []
+
+    threads = 1.upto(thread_count).map do |n|
+      Thread.start(n) do |tn|
+        sleep(rand)
+        worked_thread_numbers << tn
+        ulids << generator.generate(moment: moment)
+      end
+    end
+
+    threads.each(&:join)
+
+    assert_equal(thread_count, worked_thread_numbers.uniq.size)
+    assert_not_equal(worked_thread_numbers.sort, worked_thread_numbers)
+
+    assert do
+      ulids.map(&:to_time).uniq == [moment]
+    end
+
+    ulids.sort.each_cons(2) do |pred, succ|
+      assert do
+        pred.to_i.succ == succ.to_i
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #60 

This PR added a test, it `frequently` failed as below in my machine.

```
$ bundle exec ruby test/test_ulid_monotonic_generator_thread_safety.rb
Started
F
=================================================================================================================================================================
Failure: test_thread_safe(TestULIDMonotonicGeneratorThreadSafety):
          pred.to_i.succ == succ.to_i
          |    |    |    |  |    |
          |    |    |    |  |    1777027686520740176855546082469887928
          |    |    |    |  ULID(2016-07-30 23:54:10.259 UTC: 01ARZ3NDEKX9F357AW3WGXGFXR)
          |    |    |    false
          |    |    1777027686520740176855546082469887929
          |    1777027686520740176855546082469887928
          ULID(2016-07-30 23:54:10.259 UTC: 01ARZ3NDEKX9F357AW3WGXGFXR)
test/test_ulid_monotonic_generator_thread_safety.rb:33:in `block in test_thread_safe'
     30:     end
     31:
     32:     ulids.sort.each_cons(2) do |pred, succ|
  => 33:       assert do
     34:         pred.to_i.succ == succ.to_i
     35:       end
     36:     end
```

And CI shows errors as below.

* https://github.com/kachick/ruby-ulid/runs/2535545774
* https://github.com/kachick/ruby-ulid/runs/2535545757

<img width="1377" alt="スクリーンショット 2021-05-09 3 29 45" src="https://user-images.githubusercontent.com/1180335/117549728-f2bc7a80-b076-11eb-8ee8-cadef4a0022a.png">
<img width="1219" alt="スクリーンショット 2021-05-09 3 30 37" src="https://user-images.githubusercontent.com/1180335/117549730-f6500180-b076-11eb-80c4-95476b08c923.png">


Then I have chosen `Thread::Mutex` for the solution. Then it has been settled in running tests. Looks errors went quiet.

So I closes #60 for now, and I 🙏 this is a reasonable solution...