### PR TITLE
Return same instance for `ULID#dup`, `ULID#clone`

### DIFF
--- a/lib/ulid.rb
+++ b/lib/ulid.rb
@@ -427,6 +427,16 @@ class ULID
     super
   end
 
+  # @return [self]
+  def dup
+    self
+  end
+
+  # @return [self]
+  def clone(freeze: true)
+    self
+  end
+
   private
 
   # @return [void]

--- a/test/core/test_ulid_instance.rb
+++ b/test/core/test_ulid_instance.rb
@@ -148,6 +148,18 @@ class TestULIDInstance < Test::Unit::TestCase
     assert_equal(:ulid2, hash.fetch(ulid2))
   end
 
+  def test_dup
+    ulid = ULID.sample
+    assert_same(ulid, ulid.dup)
+  end
+
+  def test_clone
+    ulid = ULID.sample
+    assert_same(ulid, ulid.clone)
+    assert_same(ulid, ulid.clone(freeze: true))
+    assert_same(ulid, ulid.clone(freeze: false))
+  end
+
   def test_to_time
     ulid = ULID.parse('01ARZ3NDEKTSV4RRFFQ69G5FAV')
     time = ulid.to_time


### PR DESCRIPTION
`ULID` objects do not have mutable collections, just having frozen String, Time,  and Integer. So needless to cloning in use-case.