### PR TITLE
Gather constructors in one place

### DIFF
--- a/lib/ulid/monotonic_generator.rb
+++ b/lib/ulid/monotonic_generator.rb
@@ -27,7 +27,7 @@ class ULID
         else
           @latest_entropy += 1
         end
-        ULID.from_monotonic_generator(self)
+        ULID.from_milliseconds_and_entropy(milliseconds: @latest_milliseconds, entropy: @latest_entropy)
       end
     end
 

--- a/sig/ulid.rbs
+++ b/sig/ulid.rbs
@@ -63,7 +63,7 @@ class ULID
   @milliseconds: Integer
   @entropy: Integer
   @string: String?
-  @integer: Integer?
+  @integer: Integer
   @timestamp: String?
   @randomness: String?
   @inspect: String?
@@ -86,10 +86,10 @@ class ULID
   def self.valid?: (untyped string) -> bool
   def self.scan:  (String string) -> Enumerator[self, singleton(ULID)]
                 | (String string) { (self ulid) -> void } -> singleton(ULID)
-  def self.from_monotonic_generator: (MonotonicGenerator generator) -> self
+  def self.from_milliseconds_and_entropy: (milliseconds: Integer, entropy: Integer) -> self
   attr_reader milliseconds: Integer
   attr_reader entropy: Integer
-  def initialize: (milliseconds: Integer, entropy: Integer, ?integer: Integer) -> void
+  def initialize: (milliseconds: Integer, entropy: Integer, integer: Integer) -> void
   def to_s: -> String
   def to_i: -> Integer
   alias hash to_i

--- a/test/core/test_ulid_class.rb
+++ b/test/core/test_ulid_class.rb
@@ -67,30 +67,26 @@ class TestULIDClass < Test::Unit::TestCase
     assert_match(/private method `new' called/, err.message)
   end
 
-  def test_from_monotonic_generator
-    monotonic_generator = ULID::MonotonicGenerator.new
-    monotonic_generator.latest_milliseconds = 0
-    monotonic_generator.latest_entropy = 0
-    assert_equal(ULID.parse('00000000000000000000000000'), ULID.from_monotonic_generator(monotonic_generator))
-
-    monotonic_generator.latest_milliseconds = -1
+  def from_milliseconds_and_entropy
     err = assert_raises(ArgumentError) do
-      ULID.from_monotonic_generator(monotonic_generator)
+      ULID.from_milliseconds_and_entropy(milliseconds: -1, entropy: 42)
     end
     assert_match('milliseconds and entropy should not be negative', err.message)
 
-    monotonic_generator.latest_milliseconds = 0
-    monotonic_generator.latest_entropy = -1
     err = assert_raises(ArgumentError) do
-      ULID.from_monotonic_generator(monotonic_generator)
+      ULID.from_milliseconds_and_entropy(milliseconds: 42, entropy: -1)
     end
     assert_match('milliseconds and entropy should not be negative', err.message)
 
-    [nil, BasicObject.new, '01ARZ3NDEKTSV4RRFFQ69G5FAV', 42, Time.now].each do |evil|
+    [nil, BasicObject.new, '01ARZ3NDEKTSV4RRFFQ69G5FAV', '42', Time.now, ULID.sample, 4.2, Object.new].each do |evil|
       err = assert_raises(ArgumentError) do
-        ULID.from_monotonic_generator(evil)
+        ULID.from_monotonic_generator(milliseconds: 42, entropy: evil)
       end
-      assert_match(/this method provided only for MonotonicGenerator/, err.message)
+      assert_match('milliseconds and entropy should be an `Integer`', err.message)
+      err = assert_raises(ArgumentError) do
+        ULID.from_monotonic_generator(milliseconds: evil, entropy: 42)
+      end
+      assert_match('milliseconds and entropy should be an `Integer`', err.message)
     end
   end
 


### PR DESCRIPTION
This PR aims for a part of #91.
It means revenge of https://github.com/kachick/ruby-ulid/pull/111#issuecomment-834445876

This makes slow `ULID.generate`, but the optimization is another issue.
I would like to ensure setting `@integer` in all case