### PR TITLE
Use `irb` even in tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ group :development, :test do
 end
 
 group :development do
-  gem 'irb', '>= 1.3.5'
   gem 'steep', '>= 0.44.1'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 group :development, :test do
   gem 'rake', '>= 13.0.3', '< 20'
+  gem 'irb', '>= 1.3.5'
 end
 
 group :development do

--- a/ruby-ulid.gemspec
+++ b/ruby-ulid.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rbs', '>= 1.2.0'
   gem.add_development_dependency 'benchmark-ips', '>= 2.8.4', '< 3'
   gem.add_development_dependency 'yard', '>= 0.9.26', '< 2'
+  gem.add_development_dependency 'irb', '>= 1.3.5'
 
   gem.required_ruby_version = '>= 2.6.0'
   

--- a/ruby-ulid.gemspec
+++ b/ruby-ulid.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rbs', '>= 1.2.0'
   gem.add_development_dependency 'benchmark-ips', '>= 2.8.4', '< 3'
   gem.add_development_dependency 'yard', '>= 0.9.26', '< 2'
-  gem.add_development_dependency 'irb', '>= 1.3.5'
 
   gem.required_ruby_version = '>= 2.6.0'
   

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,9 +6,8 @@ require 'warning'
 # How to use => https://test-unit.github.io/test-unit/en/
 require 'test/unit'
 
-if RUBY_VERSION >= '3.0.1'
-  require 'power_assert/colorize'
-end
+require 'irb'
+require 'power_assert/colorize'
 
 if Warning.respond_to?(:[]=) # @TODO Removable this guard after dropped ruby 2.6
   Warning[:deprecated] = true


### PR DESCRIPTION
AFAIK, `power_assert/colorize` need Ruby 3.0.1 or irb 1.3.1
Also `binding.irb` is needed for debugging...

ref: https://github.com/ruby/power_assert/tree/30349ba15b16391b175cd3e3954568a5c53d187c#configuration

Below is captured in `ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin20]`

<img width="842" alt="スクリーンショット 2021-05-10 1 53 03" src="https://user-images.githubusercontent.com/1180335/117580438-da119a80-b132-11eb-8d6c-c40e6a1c94ef.png">

power_assert is the recent favorites ❤️ 
