### PR TITLE
`ULID.min` and `ULID.max` takes `moment` as normal argument, instead of keyword arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,8 @@ ULID.min #=> ULID(1970-01-01 00:00:00.000 UTC: 00000000000000000000000000)
 ULID.max #=> ULID(10889-08-02 05:31:50.655 UTC: 7ZZZZZZZZZZZZZZZZZZZZZZZZZ)
 
 time = Time.at(946684800, Rational('123456.789')).utc #=> 2000-01-01 00:00:00.123456789 UTC
-ULID.min(moment: time) #=> ULID(2000-01-01 00:00:00.123 UTC: 00VHNCZB3V0000000000000000)
-ULID.max(moment: time) #=> ULID(2000-01-01 00:00:00.123 UTC: 00VHNCZB3VZZZZZZZZZZZZZZZZ)
+ULID.min(time) #=> ULID(2000-01-01 00:00:00.123 UTC: 00VHNCZB3V0000000000000000)
+ULID.max(time) #=> ULID(2000-01-01 00:00:00.123 UTC: 00VHNCZB3VZZZZZZZZZZZZZZZZ)
 ```
 
 `ULID#next` and `ULID#succ` returns next(successor) ULID.
@@ -388,9 +388,9 @@ Major methods can be replaced as below.
 -ULID.time(string)
 +ULID.parse(string).to_time
 -ULID.min_ulid_at(time)
-+ULID.min(moment: time).to_s
++ULID.min(time).to_s
 -ULID.max_ulid_at(time)
-+ULID.max(moment: time).to_s
++ULID.max(time).to_s
 ```
 
 NOTE: It is still having precision issue similar as `ulid gem` in the both generator and parser. I sent PRs.

--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ ULID.parse('01F4GNBXW1AM2KWW52PVT3ZY9X').patterns
 
 `ULID.min` and `ULID.max` return termination values for ULID spec.
 
+It can take `Time` instance as an optional argument. Then returns min/max ID that has limit of randomness part in the time.
+
 ```ruby
 ULID.min #=> ULID(1970-01-01 00:00:00.000 UTC: 00000000000000000000000000)
 ULID.max #=> ULID(10889-08-02 05:31:50.655 UTC: 7ZZZZZZZZZZZZZZZZZZZZZZZZZ)

--- a/benchmark/generators.rb
+++ b/benchmark/generators.rb
@@ -17,9 +17,9 @@ Benchmark.ips do |x|
   x.report('ULID.parse') { ULID.parse(encoded) }
   x.report('ULID.from_integer') { ULID.from_integer(fixed_integer) }
   x.report('ULID.min with no arguments is optimized') { ULID.min }
-  x.report('ULID.min with moment(Time)') { ULID.min(moment: moment) }
+  x.report('ULID.min with moment(Time)') { ULID.min(moment) }
   x.report('ULID.max with no arguments is optimized') { ULID.max }
-  x.report('ULID.max with moment(Time)') { ULID.max(moment: moment) }
+  x.report('ULID.max with moment(Time)') { ULID.max(moment) }
   x.report('ULID.sample with no arguments') { ULID.sample }
   x.report('ULID.sample with period') { ULID.sample(period: period) }
   x.report('ULID.at') { ULID.at(Time.now) }

--- a/lib/ulid.rb
+++ b/lib/ulid.rb
@@ -62,15 +62,15 @@ class ULID
     from_milliseconds_and_entropy(milliseconds: milliseconds_from_time(time), entropy: reasonable_entropy)
   end
 
-  # @param [Integer, Time] moment
+  # @param [Time, Integer] moment
   # @return [ULID]
-  def self.min(moment: 0)
+  def self.min(moment=0)
     0.equal?(moment) ? MIN : generate(moment: moment, entropy: 0)
   end
 
-  # @param [Integer, Time] moment
+  # @param [Time, Integer] moment
   # @return [ULID]
-  def self.max(moment: MAX_MILLISECONDS)
+  def self.max(moment=MAX_MILLISECONDS)
     MAX_MILLISECONDS.equal?(moment) ? MAX : generate(moment: moment, entropy: MAX_ENTROPY)
   end
 
@@ -168,7 +168,7 @@ class ULID
 
     case begin_element
     when Time
-      begin_ulid = min(moment: begin_element)
+      begin_ulid = min(begin_element)
     when nil
       begin_ulid = MIN
     when self
@@ -180,9 +180,9 @@ class ULID
     case end_element
     when Time
       if exclude_end
-        end_ulid = min(moment: end_element)
+        end_ulid = min(end_element)
       else
-        end_ulid = max(moment: end_element)
+        end_ulid = max(end_element)
       end
     when nil
       # The end should be max and include end, because nil end means to cover endless ULIDs until the limit

--- a/sig/ulid.rbs
+++ b/sig/ulid.rbs
@@ -79,8 +79,8 @@ class ULID
   def self.parse: (String string) -> self
   def self.from_uuidv4: (String uuid) -> ULID
   def self.from_integer: (Integer integer) -> self
-  def self.min: (?moment: moment) -> ULID
-  def self.max: (?moment: moment) -> ULID
+  def self.min: (?moment moment) -> ULID
+  def self.max: (?moment moment) -> ULID
   def self.sample: (?period: period) -> self
                  | (Integer number, ?period: period) -> Array[self]
   def self.valid?: (untyped string) -> bool

--- a/test/core/test_ulid_class.rb
+++ b/test/core/test_ulid_class.rb
@@ -117,12 +117,12 @@ class TestULIDClass < Test::Unit::TestCase
     exclude_end = time_has_more_value_than_milliseconds1...time_has_more_value_than_milliseconds2
 
     assert_equal(
-      ULID.min(moment: ULID.floor(time_has_more_value_than_milliseconds1))..ULID.max(moment: ULID.floor(time_has_more_value_than_milliseconds2)),
+      ULID.min(ULID.floor(time_has_more_value_than_milliseconds1))..ULID.max(ULID.floor(time_has_more_value_than_milliseconds2)),
       ULID.range(include_end)
     )
 
     assert_equal(
-      ULID.min(moment: ULID.floor(time_has_more_value_than_milliseconds1))...ULID.min(moment: ULID.floor(time_has_more_value_than_milliseconds2)),
+      ULID.min(ULID.floor(time_has_more_value_than_milliseconds1))...ULID.min(ULID.floor(time_has_more_value_than_milliseconds2)),
       ULID.range(exclude_end)
     )
 
@@ -134,23 +134,23 @@ class TestULIDClass < Test::Unit::TestCase
     exclude_end_and_nil_end = time_has_more_value_than_milliseconds1...nil
 
     assert_equal(
-      ULID.min(moment: ULID.floor(time_has_more_value_than_milliseconds1))..ULID.max,
+      ULID.min(ULID.floor(time_has_more_value_than_milliseconds1))..ULID.max,
       ULID.range(include_end_and_nil_end)
     )
 
     # The end should be max and include end, because nil end means to cover endless ULIDs until the limit
     assert_equal(
-      ULID.min(moment: ULID.floor(time_has_more_value_than_milliseconds1))..ULID.max,
+      ULID.min(ULID.floor(time_has_more_value_than_milliseconds1))..ULID.max,
       ULID.range(exclude_end_and_nil_end)
     )
 
     if RUBY_VERSION >= '2.7'
       assert_equal(
-        ULID.min..ULID.max(moment: ULID.floor(time_has_more_value_than_milliseconds2)),
+        ULID.min..ULID.max(ULID.floor(time_has_more_value_than_milliseconds2)),
         ULID.range(nil..time_has_more_value_than_milliseconds2)
       )
       assert_equal(
-        ULID.min...ULID.min(moment: ULID.floor(time_has_more_value_than_milliseconds2)),
+        ULID.min...ULID.min(ULID.floor(time_has_more_value_than_milliseconds2)),
         ULID.range(nil...time_has_more_value_than_milliseconds2)
       )
       assert_equal(
@@ -164,7 +164,7 @@ class TestULIDClass < Test::Unit::TestCase
     end
 
     assert_equal(
-      range = ULID.min(moment: ULID.floor(time_has_more_value_than_milliseconds1))..ULID.max(moment: ULID.floor(time_has_more_value_than_milliseconds1)),
+      range = ULID.min(ULID.floor(time_has_more_value_than_milliseconds1))..ULID.max(ULID.floor(time_has_more_value_than_milliseconds1)),
       ULID.range(time_has_more_value_than_milliseconds1..time_has_more_value_than_milliseconds1)
     )
     assert_equal(true, range.cover?(ULID.generate(moment: time_has_more_value_than_milliseconds1)))
@@ -193,7 +193,7 @@ class TestULIDClass < Test::Unit::TestCase
 
     # Below section is for some edge cases ref: https://github.com/kachick/ruby-ulid/issues/74
     assert_equal(
-      range = ULID.min(moment: ULID.floor(time_has_more_value_than_milliseconds1))...ULID.min(moment: ULID.floor(time_has_more_value_than_milliseconds1)),
+      range = ULID.min(ULID.floor(time_has_more_value_than_milliseconds1))...ULID.min(ULID.floor(time_has_more_value_than_milliseconds1)),
       ULID.range(time_has_more_value_than_milliseconds1...time_has_more_value_than_milliseconds1)
     )
     assert_equal(false, range.cover?(ULID.generate(moment: time_has_more_value_than_milliseconds1)))
@@ -201,7 +201,7 @@ class TestULIDClass < Test::Unit::TestCase
     assert_equal(false, range.cover?(range.end))
 
     assert_equal(
-      range = ULID.min(moment: ULID.floor(time_has_more_value_than_milliseconds2))..ULID.max(moment: ULID.floor(time_has_more_value_than_milliseconds1)),
+      range = ULID.min(ULID.floor(time_has_more_value_than_milliseconds2))..ULID.max(ULID.floor(time_has_more_value_than_milliseconds1)),
       ULID.range(time_has_more_value_than_milliseconds2..time_has_more_value_than_milliseconds1)
     )
     assert_equal(false, range.cover?(ULID.generate(moment: time_has_more_value_than_milliseconds2)))
@@ -210,7 +210,7 @@ class TestULIDClass < Test::Unit::TestCase
     assert_equal(false, range.cover?(range.end))
 
     assert_equal(
-      range = ULID.min(moment: ULID.floor(time_has_more_value_than_milliseconds2))...ULID.min(moment: ULID.floor(time_has_more_value_than_milliseconds1)),
+      range = ULID.min(ULID.floor(time_has_more_value_than_milliseconds2))...ULID.min(ULID.floor(time_has_more_value_than_milliseconds1)),
       ULID.range(time_has_more_value_than_milliseconds2...time_has_more_value_than_milliseconds1)
     )
     assert_equal(false, range.cover?(ULID.generate(moment: time_has_more_value_than_milliseconds2)))
@@ -420,14 +420,14 @@ class TestULIDClass < Test::Unit::TestCase
     assert_equal(ULID.parse('00000000000000000000000000'), ULID.min)
     time = Time.at(946684800, Rational('123456.789')).utc
     ulid = ULID.generate(moment: time)
-    assert_equal(ulid.timestamp + '0000000000000000', ULID.min(moment: time).to_s)
+    assert_equal(ulid.timestamp + '0000000000000000', ULID.min(time).to_s)
     milliseconds = 42
     ulid = ULID.generate(moment: milliseconds)
-    assert_equal(ulid.timestamp + '0000000000000000', ULID.min(moment: milliseconds).to_s)
+    assert_equal(ulid.timestamp + '0000000000000000', ULID.min(milliseconds).to_s)
 
-    assert_equal(ULID.min(moment: milliseconds), ULID.min(moment: milliseconds))
-    assert_not_same(ULID.min(moment: milliseconds), ULID.min(moment: milliseconds))
-    assert_equal(false, ULID.min(moment: milliseconds).frozen?)
+    assert_equal(ULID.min(milliseconds), ULID.min(milliseconds))
+    assert_not_same(ULID.min(milliseconds), ULID.min(milliseconds))
+    assert_equal(false, ULID.min(milliseconds).frozen?)
 
     # For optimization
     assert_same(ULID.min, ULID.min)
@@ -438,14 +438,14 @@ class TestULIDClass < Test::Unit::TestCase
     assert_equal(ULID.parse('7ZZZZZZZZZZZZZZZZZZZZZZZZZ'), ULID.max)
     time = Time.at(946684800, Rational('123456.789')).utc
     ulid = ULID.generate(moment: time)
-    assert_equal(ulid.timestamp + 'ZZZZZZZZZZZZZZZZ', ULID.max(moment: time).to_s)
+    assert_equal(ulid.timestamp + 'ZZZZZZZZZZZZZZZZ', ULID.max(time).to_s)
     milliseconds = 42
     ulid = ULID.generate(moment: milliseconds)
-    assert_equal(ulid.timestamp + 'ZZZZZZZZZZZZZZZZ', ULID.max(moment: milliseconds).to_s)
+    assert_equal(ulid.timestamp + 'ZZZZZZZZZZZZZZZZ', ULID.max(milliseconds).to_s)
 
-    assert_equal(ULID.max(moment: milliseconds), ULID.max(moment: milliseconds))
-    assert_not_same(ULID.max(moment: milliseconds), ULID.max(moment: milliseconds))
-    assert_equal(false, ULID.max(moment: milliseconds).frozen?)
+    assert_equal(ULID.max(milliseconds), ULID.max(milliseconds))
+    assert_not_same(ULID.max(milliseconds), ULID.max(milliseconds))
+    assert_equal(false, ULID.max(milliseconds).frozen?)
 
     # For optimization
     assert_same(ULID.max, ULID.max)

--- a/test/core/test_ulid_example_values.rb
+++ b/test/core/test_ulid_example_values.rb
@@ -9,10 +9,10 @@ class TestULIDWithExampleValues < Test::Unit::TestCase
     assert_equal('0000XSNJG0', ULID.generate(moment: Time.at(1000000)).timestamp)
     time = Time.utc(2019, 3, 31, 3, 51, 23, 536000)
     assert_equal(time, ULID.parse('01D78XZ44G0000000000000000').to_time)
-    assert_equal('01D78XZ44G0000000000000000', ULID.min(moment: time).to_s)
+    assert_equal('01D78XZ44G0000000000000000', ULID.min(time).to_s)
 
     # https://github.com/oklog/ulid/blob/e7ac4de44d238ff4707cc84b9c98ae471f31e2d1/ulid_test.go#L204-L213
-    assert_equal('01ARYZ6S410000000000000000', ULID.min(moment: 1469918176385).to_s)
+    assert_equal('01ARYZ6S410000000000000000', ULID.min(1469918176385).to_s)
 
     # https://github.com/oklog/ulid/blob/e7ac4de44d238ff4707cc84b9c98ae471f31e2d1/ulid_test.go#L472-L487
     assert_instance_of(ULID, ULID.parse('00000000000000000000000000'))

--- a/test/core/test_ulid_monotonic_generator.rb
+++ b/test/core/test_ulid_monotonic_generator.rb
@@ -65,7 +65,7 @@ class TestULIDMonotonicGenerator < Test::Unit::TestCase
   end
 
   def test_generate_raises_overflow_when_called_on_max_entropy
-    max_ulid_in_a_milliseconds = ULID.max(moment: 42)
+    max_ulid_in_a_milliseconds = ULID.max(42)
 
     @generator.latest_milliseconds = max_ulid_in_a_milliseconds.milliseconds
     @generator.latest_entropy = ULID::MAX_ENTROPY.pred


### PR DESCRIPTION
Just aims to simplify.
I don't think any case of this method extended in future.
So using `keyword arguments` is overdo.

Of course this is a big breaking change. But I didn't release the `0.1.0` yet. ref: #88