### PR TITLE
Improve `ULID::MonotonicGenerator`

### DIFF
--- a/sig/ulid.rbs
+++ b/sig/ulid.rbs
@@ -49,10 +49,14 @@ class ULID
   class MonotonicGenerator
     attr_accessor latest_milliseconds: Integer
     attr_accessor latest_entropy: Integer
+    attr_reader last: ULID | nil
     def initialize: -> void
     def generate: (?moment: moment) -> ULID
-    def reset: -> void
+    def inspect: -> String
+    alias to_s inspect
     def freeze: -> void
+    private
+    def reset: -> void
   end
 
   type octets = [Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer]

--- a/test/concurrency/test_ulid_monotonic_generator_thread_safety.rb
+++ b/test/concurrency/test_ulid_monotonic_generator_thread_safety.rb
@@ -6,6 +6,23 @@ require_relative '../helper'
 class TestULIDMonotonicGeneratorThreadSafety < Test::Unit::TestCase
   include ULIDAssertions
 
+  def test_prefer_error_rather_than_returns_unsuitable
+    generator = ULID::MonotonicGenerator.new
+
+    assert_nil(generator.last)
+
+    ulid = generator.generate
+    assert_same(ulid, generator.last)
+
+    generator.instance_exec do
+      @last = ULID.at(Time.now + 2)
+    end
+
+    assert_raises(ULID::MonotonicGenerator::ConcurrencyError) do
+      generator.generate
+    end
+  end
+
   def test_thread_safe_with_fixed_times
     generator = ULID::MonotonicGenerator.new
     thread_count = 5000

--- a/test/core/test_ulid_monotonic_generator.rb
+++ b/test/core/test_ulid_monotonic_generator.rb
@@ -72,7 +72,7 @@ class TestULIDMonotonicGenerator < Test::Unit::TestCase
 
     assert_equal(max_ulid_in_a_milliseconds, @generator.generate(moment: max_ulid_in_a_milliseconds.milliseconds))
 
-    @generator.reset
+    @generator.__send__ :reset
 
     @generator.latest_milliseconds = max_ulid_in_a_milliseconds.milliseconds
     @generator.latest_entropy = ULID::MAX_ENTROPY
@@ -88,5 +88,26 @@ class TestULIDMonotonicGenerator < Test::Unit::TestCase
     end
 
     assert_equal(false, @generator.frozen?)
+  end
+
+  def test_last
+    assert_nil(@generator.last)
+
+    ulid1 = @generator.generate
+    assert_same(ulid1, @generator.last)
+    ulid2 = @generator.generate
+    assert_same(ulid2, @generator.last)
+
+    @generator.__send__ :reset
+    assert_nil(@generator.last)
+  end
+
+  def test_inspect
+    assert_equal('ULID::MonotonicGenerator(last: nil)', @generator.inspect)
+    assert_not_same(@generator.inspect, @generator.inspect)
+
+    ulid = @generator.generate
+
+    assert_equal("ULID::MonotonicGenerator(last: #{ulid.inspect})", @generator.inspect)
   end
 end


### PR DESCRIPTION
* Ensure unsuitable products should not be returned. Raise error instead
* Hide private api `#reset`
* Improve `#inspect` and `#to_s`

Resolves #136

After this.

```
irb(main):001:0> mg = ULID::MonotonicGenerator.new
=> ULID::MonotonicGenerator(last: nil)
irb(main):002:0> mg.generate
=> ULID(2021-05-11 18:27:13.749 UTC: 01F5EAXPPNKNZH8XCDH6Z2SH59)
irb(main):003:0> mg
=> ULID::MonotonicGenerator(last: ULID(2021-05-11 18:27:13.749 UTC: 01F5EAXPPNKNZH8XCDH6Z2SH59))
irb(main):004:0> mg.generate
=> ULID(2021-05-11 18:27:19.990 UTC: 01F5EAXWSP1B0PPHVGS4WW34GW)
irb(main):005:0> mg
=> ULID::MonotonicGenerator(last: ULID(2021-05-11 18:27:19.990 UTC: 01F5EAXWSP1B0PPHVGS4WW34GW))
```

I think this is not a breaking change.