### PR TITLE
Cover original `Crockford's base32` formats

### DIFF
--- a/lib/ulid.rb
+++ b/lib/ulid.rb
@@ -246,17 +246,24 @@ class ULID
   end
 
   # @param [String, #to_str] string
+  # @param [Boolean] crockford_original
   # @return [ULID]
   # @raise [ParserError] if the given format is not correct for ULID specs
-  def self.parse(string)
+  def self.parse(string, crockford_original: false)
     string = String.try_convert(string)
     raise ArgumentError, 'ULID.parse takes only strings' unless string
 
-    unless STRICT_PATTERN_WITH_CROCKFORD_BASE32_SUBSET.match?(string)
-      raise ParserError, "given `#{string}` does not match to `#{STRICT_PATTERN_WITH_CROCKFORD_BASE32_SUBSET.inspect}`"
+    integer = if crockford_original
+      CrockfordBase32.decode(string)
+    else
+      unless STRICT_PATTERN_WITH_CROCKFORD_BASE32_SUBSET.match?(string)
+        raise ParserError, "given `#{string}` does not match to `#{STRICT_PATTERN_WITH_CROCKFORD_BASE32_SUBSET.inspect}`"
+      end
+
+      CrockfordBase32.decode(string)
     end
 
-    from_integer(CrockfordBase32.decode(string))
+    from_integer(integer)
   end
 
   # @param [String, #to_str] string

--- a/sig/ulid.rbs
+++ b/sig/ulid.rbs
@@ -81,7 +81,7 @@ class ULID
   def self.milliseconds_from_moment: (moment moment) -> Integer
   def self.range: (period period) -> Range[ULID]
   def self.floor: (Time time) -> Time
-  def self.parse: (String string) -> self
+  def self.parse: (String string, ?crockford_original: boolish) -> self
   def self.from_uuidv4: (String uuid) -> ULID
   def self.from_integer: (Integer integer) -> self
   def self.min: (?moment moment) -> ULID

--- a/test/core/test_ulid_class.rb
+++ b/test/core/test_ulid_class.rb
@@ -36,6 +36,8 @@ class TestULIDClass < Test::Unit::TestCase
     assert_equal(string, parsed.to_s)
     assert_equal(string, ULID.parse(string.downcase).to_s)
 
+    assert_equal(parsed, ULID.parse(string, crockford_original: true))
+
     [
       '',
       "01ARZ3NDEKTSV4RRFFQ69G5FAV\n",
@@ -46,15 +48,29 @@ class TestULIDClass < Test::Unit::TestCase
         ULID.parse(invalid)
       end
       assert_match(/does not match to/, err.message)
+
+      err = assert_raises(ULID::ParserError) do
+        ULID.parse(invalid, crockford_original: true)
+      end
+      assert_match(/does not match to/, err.message)
     end
 
     assert_raises(ArgumentError) do
       ULID.parse
     end
 
+    assert_raises(ArgumentError) do
+      ULID.parse(crockford_original: true)
+    end
+
     [nil, 42, string.to_sym, BasicObject.new, Object.new, parsed].each do |evil|
       err = assert_raises(ArgumentError) do
         ULID.parse(evil)
+      end
+      assert_equal('ULID.parse takes only strings', err.message)
+
+      err = assert_raises(ArgumentError) do
+        ULID.parse(evil, crockford_original: true)
       end
       assert_equal('ULID.parse takes only strings', err.message)
     end


### PR DESCRIPTION
Addressing for #78 and #57

might relate to #86

[ci skip]