### PR TITLE
Clarify `ULID::MonotonicGenerator#{prev, inspect}` is `not` Thread-safety feature

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ basic_test_tasks = [:test_core, :test_experimental]
 task test: basic_test_tasks
 
 # Basically checked in CI only
-task test_all: basic_test_tasks | [:test_many_data, :test_concurrency]
+task test_all: basic_test_tasks | [:test_many_data, :test_concurrency, :test_longtime]
 
 Rake::TestTask.new(:test_core) do |tt|
   tt.pattern = 'test/core/**/test_*.rb'
@@ -40,6 +40,12 @@ end
 
 Rake::TestTask.new(:test_concurrency) do |tt|
   tt.pattern = 'test/concurrency/**/test_*.rb'
+  tt.verbose = true
+  tt.warning = true
+end
+
+Rake::TestTask.new(:test_longtime) do |tt|
+  tt.pattern = 'test/longtime/**/test_*.rb'
   tt.verbose = true
   tt.warning = true
 end

--- a/lib/ulid/monotonic_generator.rb
+++ b/lib/ulid/monotonic_generator.rb
@@ -4,9 +4,6 @@
 
 class ULID
   class MonotonicGenerator
-    # @return [ULID, nil]
-    attr_reader :prev
-
     undef_method :instance_variable_set
 
     def initialize
@@ -14,9 +11,18 @@ class ULID
       @prev = nil
     end
 
+    # @return [ULID, nil]
+    def prev
+      @mutex.synchronize do
+        @prev
+      end
+    end
+
     # @return [String]
     def inspect
-      "ULID::MonotonicGenerator(prev: #{@prev.inspect})"
+      @mutex.synchronize do
+        "ULID::MonotonicGenerator(prev: #{@prev.inspect})"
+      end
     end
     alias_method :to_s, :inspect
 

--- a/lib/ulid/monotonic_generator.rb
+++ b/lib/ulid/monotonic_generator.rb
@@ -4,6 +4,9 @@
 
 class ULID
   class MonotonicGenerator
+    # @return [ULID, nil]
+    attr_reader :prev
+
     undef_method :instance_variable_set
 
     def initialize
@@ -11,18 +14,9 @@ class ULID
       @prev = nil
     end
 
-    # @return [ULID, nil]
-    def prev
-      @mutex.synchronize do
-        @prev
-      end
-    end
-
     # @return [String]
     def inspect
-      @mutex.synchronize do
-        "ULID::MonotonicGenerator(prev: #{@prev.inspect})"
-      end
+      "ULID::MonotonicGenerator(prev: #{@prev.inspect})"
     end
     alias_method :to_s, :inspect
 

--- a/sig/ulid.rbs
+++ b/sig/ulid.rbs
@@ -53,6 +53,8 @@ class ULID < Object
 
   class MonotonicGenerator
     @mutex: Thread::Mutex
+
+    # The returned value is `not` Thready-safety
     attr_reader prev: ULID | nil
 
     # A pribate API. Should not be used in your code.
@@ -60,6 +62,8 @@ class ULID < Object
 
     # See [How to keep `Sortable` even if in same timestamp](https://github.com/kachick/ruby-ulid#how-to-keep-sortable-even-if-in-same-timestamp)
     def generate: (?moment: moment) -> ULID
+
+    # The returned value is `not` Thready-safety
     def inspect: -> String
     alias to_s inspect
     def freeze: -> void

--- a/test/concurrency/test_ulid_monotonic_generator_thread_safety.rb
+++ b/test/concurrency/test_ulid_monotonic_generator_thread_safety.rb
@@ -4,14 +4,63 @@
 require_relative '../helper'
 
 class TestULIDMonotonicGeneratorThreadSafety < Test::Unit::TestCase
+  include ULIDHelpers
   include ULIDAssertions
 
-  def sleeping_time
-    # NOTE: `SecureRandom.random_number(0.42..1.42)` made `SIGSEGV` on `ruby 3.0.1p64 (2021-04-05 revision 0fb782ee38) [x86_64-darwin20]`
-    SecureRandom.random_number(0.12..0.42)
+  def test_thread_safe_prev
+    generator = ULID::MonotonicGenerator.new
+    thread_count = 2000
+
+    prevs = []
+
+    threads = 1.upto(thread_count).map do |n|
+      Thread.start(n) do |_thread_number|
+        sleep(sleeping_time)
+        prevs << generator.prev
+        generator.generate
+      end
+    end
+
+    threads.each(&:join)
+
+    assert_equal(1, prevs.count(nil))
+    assert(prevs.compact.all?(ULID))
+    assert_equal(thread_count, prevs.size)
+
+    # This branch does not mean to omit Ruby 2.6. Just to use Enumerable#tally for debug
+    if RUBY_VERSION >= '2.7'
+      weirds = prevs.tally.select{ |_ulid, count| count > 1 }
+      assert do
+        weirds.empty?
+      end
+    end
+    # binding.irb
+
+    assert_equal(thread_count, prevs.uniq.size)
   end
 
-  def test_thread_safe_without_arguments
+  def test_thread_safe_inspect
+    generator = ULID::MonotonicGenerator.new
+    thread_count = 2000
+
+    inspects = []
+
+    threads = 1.upto(thread_count).map do |n|
+      Thread.start(n) do |_thread_number|
+        sleep(sleeping_time)
+        inspects << generator.inspect
+        generator.generate
+      end
+    end
+
+    threads.each(&:join)
+
+    assert(inspects.all?(String))
+    assert_equal(thread_count, inspects.size)
+    assert_equal(thread_count, inspects.uniq.size)
+  end
+
+  def test_thread_safe_generate_without_arguments
     generator = ULID::MonotonicGenerator.new
     thread_count = 2000
     starts_at = Time.now
@@ -34,6 +83,8 @@ class TestULIDMonotonicGeneratorThreadSafety < Test::Unit::TestCase
     assert_equal(thread_count, worked_thread_numbers.uniq.size)
     assert_not_equal(worked_thread_numbers.sort, worked_thread_numbers)
 
+    assert_equal(thread_count, ulids.uniq.size)
+
     ulids_by_the_time = ulids.group_by(&:to_time)
 
     # I don't know thw `42` is reasonable or not :yum:
@@ -52,7 +103,7 @@ class TestULIDMonotonicGeneratorThreadSafety < Test::Unit::TestCase
     end
   end
 
-  def test_thread_safe_with_fixed_times
+  def test_thread_safe_generate_with_fixed_times
     generator = ULID::MonotonicGenerator.new
     thread_count = 2000
     moment = ULID.parse('01ARZ3NDEKTSV4RRFFQ69G5FAV').to_time
@@ -83,7 +134,7 @@ class TestULIDMonotonicGeneratorThreadSafety < Test::Unit::TestCase
   end
 
   # I don't have confident for this test is the reasonable one... Concurrency is hard to human. :cry:
-  def test_thread_safe_with_randomized_time
+  def test_thread_safe_generate_with_randomized_time
     generator = ULID::MonotonicGenerator.new
     thread_count = 3000
     initial_and_median = ULID.generate

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -21,6 +21,13 @@ end
 require_relative '../lib/ulid'
 
 class Test::Unit::TestCase
+  module ULIDHelpers
+    def sleeping_time
+      # NOTE: `SecureRandom.random_number(0.42..1.42)` made `SIGSEGV` on `ruby 3.0.1p64 (2021-04-05 revision 0fb782ee38) [x86_64-darwin20]`
+      SecureRandom.random_number(0.12..0.42)
+    end
+  end
+
   module ULIDAssertions
     def assert_acceptable_randomized_string(ulid)
       assert do

--- a/test/longtime/test_ulid_monotonic_generator_single_thread.rb
+++ b/test/longtime/test_ulid_monotonic_generator_single_thread.rb
@@ -1,0 +1,42 @@
+# coding: utf-8
+# frozen_string_literal: true
+
+require_relative '../helper'
+
+class TestULIDMonotonicGeneratorWithSingleThread < Test::Unit::TestCase
+  include ULIDAssertions
+
+  def test_prev_with_many_data
+    generator = ULID::MonotonicGenerator.new
+    prevs = []
+
+    1.upto(2000).map do |n|
+      sleep(0.0042)
+      prevs << generator.prev
+      generator.generate
+    end
+
+    assert_equal(1, prevs.count(nil))
+    assert_equal(2000, prevs.size)
+    assert_equal(2000, prevs.uniq.size)
+
+    times_count = prevs.compact.count(&:to_time)
+    assert do
+      420 < times_count
+    end
+  end
+
+  def test_inspect_with_many_data
+    generator = ULID::MonotonicGenerator.new
+    prevs = []
+
+    1.upto(2000).map do |n|
+      sleep(0.0042)
+      prevs << generator.inspect
+      generator.generate
+    end
+
+    assert_equal(2000, prevs.size)
+    assert_equal(2000, prevs.uniq.size)
+  end
+end

--- a/test/longtime/test_ulid_monotonic_generator_single_thread.rb
+++ b/test/longtime/test_ulid_monotonic_generator_single_thread.rb
@@ -10,7 +10,7 @@ class TestULIDMonotonicGeneratorWithSingleThread < Test::Unit::TestCase
     generator = ULID::MonotonicGenerator.new
     prevs = []
 
-    1.upto(2000).map do |n|
+    1.upto(2000) do
       sleep(0.0042)
       prevs << generator.prev
       generator.generate
@@ -30,7 +30,7 @@ class TestULIDMonotonicGeneratorWithSingleThread < Test::Unit::TestCase
     generator = ULID::MonotonicGenerator.new
     prevs = []
 
-    1.upto(2000).map do |n|
+    1.upto(2000) do
       sleep(0.0042)
       prevs << generator.inspect
       generator.generate


### PR DESCRIPTION
📝 

If want to ensure they are Thready-safety as `#generate`, we should use same mutex locking in outer scope. 
It is overdo compared with the features. So I omit.