### PR TITLE
Prefer `Monitor` rather than `Thread::Mutex`

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ sample_ulids_by_the_time.take(5) #=>
 ulids.sort == ulids #=> true
 ```
 
-Same generator does not generate duplicated ULIDs even in multi threads environment. It is implemented with [Thread::Mutex](https://github.com/ruby/ruby/blob/5f8bca32571fa9c651f6903d36f66082363f8879/thread_sync.c#L1572-L1582)
+Same generator does not generate duplicated ULIDs even in multi threads environment. It is implemented with [Monitor](https://bugs.ruby-lang.org/issues/16255)
 
 ### Filtering IDs with `Time`
 

--- a/Rakefile
+++ b/Rakefile
@@ -56,7 +56,7 @@ multitask simulate_ci: [:test_all, :validate_signatures, :rubocop]
 
 namespace :signature do
   task :validate do
-    sh 'bundle exec rbs -rsecurerandom -I sig validate'
+    sh 'bundle exec rbs -rsecurerandom -rmonitor -I sig validate'
   end
 
   task :check_false_positive do

--- a/Steepfile
+++ b/Steepfile
@@ -3,5 +3,5 @@ target :lib do
 
   check 'lib'
 
-  library 'securerandom'
+  library 'securerandom', 'monitor'
 end

--- a/lib/ulid/monotonic_generator.rb
+++ b/lib/ulid/monotonic_generator.rb
@@ -4,13 +4,15 @@
 
 class ULID
   class MonotonicGenerator
+    include MonitorMixin
+
     # @return [ULID, nil]
     attr_reader :prev
 
     undef_method :instance_variable_set
 
     def initialize
-      @mutex = Thread::Mutex.new
+      super()
       @prev = nil
     end
 
@@ -26,7 +28,7 @@ class ULID
     # @raise [UnexpectedError] if the generated ULID is an invalid value in monotonicity spec.
     #   Basically will not happen. Just means this feature prefers error rather than invalid value.
     def generate(moment: ULID.current_milliseconds)
-      @mutex.synchronize do
+      synchronize do
         unless @prev
           @prev = ULID.generate(moment: moment)
           return @prev

--- a/sig/ulid.rbs
+++ b/sig/ulid.rbs
@@ -54,16 +54,35 @@ class ULID < Object
   class MonotonicGenerator
     include MonitorMixin
 
-    # The returned value is `not` Thready-safety
+    # Returned value is `basically not` Thread-safety
+    # If you want to keep Thread-safety, keep to call {#generate} only in same {#synchronize} block
+    #
+    # ```ruby
+    # generator.synchronize do
+    #   generator.prev
+    #   generator.inspect
+    #   generator.generate
+    # end
+    # ```
     attr_reader prev: ULID | nil
 
     # A pribate API. Should not be used in your code.
     def initialize: -> void
 
     # See [How to keep `Sortable` even if in same timestamp](https://github.com/kachick/ruby-ulid#how-to-keep-sortable-even-if-in-same-timestamp)
+    # The `Thread-safety` is implemented with [Monitor](https://bugs.ruby-lang.org/issues/16255)
     def generate: (?moment: moment) -> ULID
 
-    # The returned value is `not` Thready-safety
+    # Returned value is `basically not` Thread-safety
+    # If you want to keep Thread-safety, keep to call {#generate} only in same {#synchronize} block
+    #
+    # ```ruby
+    # generator.synchronize do
+    #   generator.prev
+    #   generator.inspect
+    #   generator.generate
+    # end
+    # ```
     def inspect: -> String
     alias to_s inspect
     def freeze: -> void

--- a/sig/ulid.rbs
+++ b/sig/ulid.rbs
@@ -52,7 +52,7 @@ class ULID < Object
   end
 
   class MonotonicGenerator
-    @mutex: Thread::Mutex
+    include MonitorMixin
 
     # The returned value is `not` Thready-safety
     attr_reader prev: ULID | nil


### PR DESCRIPTION
Resolves #149

Partially revenge of #146 