### PR TITLE
Add tests to check current behavior of MonotonicGenerator dup/clone case

### DIFF
--- a/test/concurrency/test_ulid_monotonic_generator_thread_safety.rb
+++ b/test/concurrency/test_ulid_monotonic_generator_thread_safety.rb
@@ -195,7 +195,7 @@ class TestULIDMonotonicGeneratorThreadSafety < Test::Unit::TestCase
     assert(prevs.compact.all?(ULID))
     assert_equal(thread_count, prevs.size)
 
-    omit("ULID::MonotonicGenerator#pred can't be guaranteed the returned value is Thread-safety") do
+    omit("ULID::MonotonicGenerator#pred can't be guaranteed the returned value is Thread-safety when separately called with #generate") do
       assert_equal(1, prevs.count(nil)) # Basically passed, but can't be guaranteed
 
       # This branch does not mean to omit Ruby 2.6. Just to use Enumerable#tally for debug
@@ -229,7 +229,7 @@ class TestULIDMonotonicGeneratorThreadSafety < Test::Unit::TestCase
     assert(inspects.all?(String))
     assert_equal(thread_count, inspects.size)
 
-    omit("ULID::MonotonicGenerator#inspect can't be guaranteed the returned value is Thread-safety") do
+    omit("ULID::MonotonicGenerator#inspect can't be guaranteed the returned value is Thread-safety when separately called with #generate") do
       assert_equal(thread_count, inspects.uniq.size)
     end
   end

--- a/test/concurrency/test_ulid_monotonic_generator_thread_safety.rb
+++ b/test/concurrency/test_ulid_monotonic_generator_thread_safety.rb
@@ -274,4 +274,58 @@ class TestULIDMonotonicGeneratorThreadSafety < Test::Unit::TestCase
 
     assert_equal(thread_count, inspects.uniq.size)
   end
+
+  def test_duplicated_generator
+    generator = ULID::MonotonicGenerator.new
+    duped = generator.dup
+    thread_count = 2000
+
+    ulids = []
+
+    threads1 = 1.upto(thread_count / 2).map do |n|
+      Thread.start(n) do |_thread_number|
+        sleep(sleeping_time)
+        ulids << generator.generate
+      end
+    end
+
+    threads2 = ((thread_count / 2) + 1).upto(thread_count).map do |n|
+      Thread.start(n) do |_thread_number|
+        sleep(sleeping_time)
+        ulids << duped.generate
+      end
+    end
+
+    [*threads1, *threads2].each(&:join)
+
+    assert_equal(thread_count, ulids.size)
+    assert_equal(thread_count, ulids.uniq.size)
+  end
+
+  def test_cloned_generator
+    generator = ULID::MonotonicGenerator.new
+    cloned = generator.clone
+    thread_count = 2000
+
+    ulids = []
+
+    threads1 = 1.upto(thread_count / 2).map do |n|
+      Thread.start(n) do |_thread_number|
+        sleep(sleeping_time)
+        ulids << generator.generate
+      end
+    end
+
+    threads2 = ((thread_count / 2) + 1).upto(thread_count).map do |n|
+      Thread.start(n) do |_thread_number|
+        sleep(sleeping_time)
+        ulids << cloned.generate
+      end
+    end
+
+    [*threads1, *threads2].each(&:join)
+
+    assert_equal(thread_count, ulids.size)
+    assert_equal(thread_count, ulids.uniq.size)
+  end
 end


### PR DESCRIPTION
It should depend on `MonitorMixin`. So just check the behavior. Does not mean to keep this as a spec.

Follow #151

```
irb(main):001:0> monotonic_generator = ULID::MonotonicGenerator.new
=> ULID::MonotonicGenerator(prev: nil)
irb(main):002:0> mg1 = _
=> ULID::MonotonicGenerator(prev: nil)
irb(main):003:0> mg2 = mg1.dup
=> ULID::MonotonicGenerator(prev: nil)
irb(main):004:0> mg2 == mg1
=> false
irb(main):005:0> mg1.instance_variables
=> [:@mon_data, :@mon_data_owner_object_id, :@prev]
irb(main):006:0> mg1.instance_exec { p @mon_data }
#<Monitor:0x00007fb7c18aad10>
=> #<Monitor:0x00007fb7c18aad10>
irb(main):007:0> mg1.instance_exec { p @mon_data_owner_object_id }
1640
=> 1640
irb(main):008:0> mg2.instance_exec { p @mon_data_owner_object_id }
1640
=> 1640
irb(main):009:0> mg2.instance_exec { p @mon_data }
#<Monitor:0x00007fb7c18aad10>
=> #<Monitor:0x00007fb7c18aad10>
```