### PR TITLE
Improve marshal/unmarshal logics

### DIFF
--- a/lib/ulid.rb
+++ b/lib/ulid.rb
@@ -479,6 +479,20 @@ class ULID
     super
   end
 
+  # @api private
+  # @return [Integer]
+  def marshal_dump
+    @integer
+  end
+
+  # @api private
+  # @param [Integer] integer
+  # @return [void]
+  def marshal_load(integer)
+    unmarshaled = ULID.from_integer(integer)
+    initialize(integer: unmarshaled.to_i, milliseconds: unmarshaled.milliseconds, entropy: unmarshaled.entropy)
+  end
+
   # @return [self]
   def to_ulid
     self

--- a/sig/ulid.rbs
+++ b/sig/ulid.rbs
@@ -143,7 +143,7 @@ class ULID < Object
   #
   # If you want to keep sortable even if in same timestamp, See also [ULID::MonotonicGenerator](https://github.com/kachick/ruby-ulid#how-to-keep-sortable-even-if-in-same-timestamp)
   #
-  def self.generate: (?moment: moment, ?entropy: Integer) -> self
+  def self.generate: (?moment: moment, ?entropy: Integer) -> ULID
 
   # Shorthand of `ULID.generate(moment: Time)`
   # See also [ULID.generate](https://kachick.github.io/ruby-ulid/ULID.html#generate-class_method)
@@ -157,7 +157,7 @@ class ULID < Object
   # end
   # ulids.sort == ulids #=> true
   # ```
-  def self.at: (Time time) -> self
+  def self.at: (Time time) -> ULID
 
   # A pribate API. Should not be used in your code.
   def self.current_milliseconds: -> Integer
@@ -212,7 +212,7 @@ class ULID < Object
   # ulid = ULID.parse('01ARZ3NDEKTSV4RRFFQ69G5FAV')
   # #=> ULID(2016-07-30 23:54:10.259 UTC: 01ARZ3NDEKTSV4RRFFQ69G5FAV)
   # ```
-  def self.parse: (_ToStr string) -> self
+  def self.parse: (_ToStr string) -> ULID
 
   # ```ruby
   # # Currently experimental feature, so needed to load the extension.
@@ -226,7 +226,7 @@ class ULID < Object
   #
   # See also [Why this is experimental?](https://github.com/kachick/ruby-ulid/issues/76)
   def self.from_uuidv4: (String uuid) -> ULID
-  def self.from_integer: (Integer integer) -> self
+  def self.from_integer: (Integer integer) -> ULID
 
   # Returns termination values for ULID spec.
   #
@@ -318,8 +318,8 @@ class ULID < Object
   # #  ULID(2021-04-28 16:49:06.484 UTC: 01F4CP4PDM214Q6H3KJP7DYJRR),
   # #  ULID(2021-04-28 15:05:06.808 UTC: 01F4CG68ZRST94T056KRZ5K9S4)]
   # ```
-  def self.sample: (?period: period) -> self
-                 | (Integer number, ?period: period) -> Array[self]
+  def self.sample: (?period: period) -> ULID
+                 | (Integer number, ?period: period) -> Array[ULID]
   def self.valid?: (untyped) -> bool
 
   # Returns normalized string
@@ -384,8 +384,8 @@ class ULID < Object
   # #  ULID(2021-04-30 05:53:12.478 UTC: 01F4GND4RYYSKNAADHQ9BNXAWJ)]
   # ```
   def self.scan:  (_ToStr string) -> Enumerator[self, singleton(ULID)]
-                | (_ToStr string) { (self ulid) -> void } -> singleton(ULID)
-  def self.from_milliseconds_and_entropy: (milliseconds: Integer, entropy: Integer) -> self
+                | (_ToStr string) { (ULID ulid) -> void } -> singleton(ULID)
+  def self.from_milliseconds_and_entropy: (milliseconds: Integer, entropy: Integer) -> ULID
   def self.try_convert: (_ToULID) -> ULID
                       | (untyped) -> nil
 
@@ -506,6 +506,12 @@ class ULID < Object
   # See also [ULID#succ](https://kachick.github.io/ruby-ulid/ULID.html#succ-instance_method)
   def pred: -> ULID?
   def freeze: -> self
+
+  # A pribate API. Should not be used in your code.
+  def marshal_dump: -> Integer
+
+  # A pribate API. Should not be used in your code.
+  def marshal_load: (Integer integer) -> void
 
   # Returns `self`
   def to_ulid: -> self

--- a/test/core/test_ulid_usecase.rb
+++ b/test/core/test_ulid_usecase.rb
@@ -114,10 +114,13 @@ class TestULIDUseCase < Test::Unit::TestCase
     assert_equal([ulid1_2, ulid1_3, ulid2, ulid3_1], ulids.grep(ULID.range(time1_2...time3_3)))
   end
 
-  # This gem does not keep compatibilities for dumped data in different versions. Even in patch version updating.
   def test_marshal_and_unmarshal
-    ulid = ULID.sample
+    # * Keep basic compatibilities for dumped data in different patch versions since `0.1.5`
+    # * Might be changed the behavior in different major/minor versions
+    # * Might be changed the behavior in different `Marshal::MAJOR_VERSION` and `Marshal::MINOR_VERSION`
+    ulid = ULID.parse('01F6K1RX8VBEA52C9V6CVQ63YK')
     dumped = Marshal.dump(ulid)
+    assert_equal((+"U:\tULIDl+\r\xD3\x0Fs73;1Q\x94[\eu\x1C\xA6y\x01").force_encoding(Encoding::ASCII_8BIT), dumped.unpack('c*').slice(2..).pack('c*'))
     unmarshaled = Marshal.load(dumped)
     assert_not_same(ulid, unmarshaled)
     assert_instance_of(ULID, unmarshaled)
@@ -135,10 +138,11 @@ class TestULIDUseCase < Test::Unit::TestCase
     assert_equal(ulid.octets, unmarshaled.octets)
     assert_equal(ulid.patterns, unmarshaled.patterns)
 
+    # Do not ensure frozen instance behaviors, this tests just check current behavior
     frozen = ULID.sample.freeze
     dumped = Marshal.dump(frozen)
     unmarshaled = Marshal.load(dumped)
     assert(!unmarshaled.frozen?)
-    assert(!unmarshaled.to_s.frozen?)
+    assert(unmarshaled.to_s.frozen?)
   end
 end


### PR DESCRIPTION
Update #128 and #130

ref: https://github.com/kachick/ruby-ulid/issues/157#issuecomment-848333218

NOTE:

This commit changes some rbs definition, because some `self` were handled as singleton class.
I don't know why, but this change makes simple for the signature in actual case.
Considering subclass is needless.