### PR TITLE
Prefer the randomness of ULID#hash rather than all uniq integers

### DIFF
--- a/lib/ulid.rb
+++ b/lib/ulid.rb
@@ -370,7 +370,11 @@ class ULID
   def to_i
     @integer
   end
-  alias_method :hash, :to_i
+
+  # @return [Integer]
+  def hash
+    [self.class, @integer].hash
+  end
 
   # @return [Integer, nil]
   def <=>(other)

--- a/lib/ulid.rb
+++ b/lib/ulid.rb
@@ -373,7 +373,7 @@ class ULID
 
   # @return [Integer]
   def hash
-    [self.class, @integer].hash
+    @integer.hash
   end
 
   # @return [Integer, nil]

--- a/test/core/test_ulid_instance.rb
+++ b/test/core/test_ulid_instance.rb
@@ -139,6 +139,11 @@ class TestULIDInstance < Test::Unit::TestCase
     uniq_hashes = ulids.map(&:hash).uniq
     assert_instance_of(Integer, uniq_hashes.first)
     assert_equal(ulids.size, uniq_hashes.size)
+
+    # They should have enough randomness similar as builtin objects. So do not depends int
+    assert do
+      (uniq_hashes & ulids.map(&:to_i)).empty?
+    end
   end
 
   def test_hash_key

--- a/test/core/test_ulid_instance.rb
+++ b/test/core/test_ulid_instance.rb
@@ -132,6 +132,15 @@ class TestULIDInstance < Test::Unit::TestCase
     assert_equal(1777027686520646174104517696511196507, ULID.parse('01ARZ3NDEKTSV4RRFFQ69G5FAV').to_i)
   end
 
+  def test_hash
+    ulids = 1000.times.map do
+      ULID.generate
+    end
+    uniq_hashes = ulids.map(&:hash).uniq
+    assert_instance_of(Integer, uniq_hashes.first)
+    assert_equal(ulids.size, uniq_hashes.size)
+  end
+
   def test_hash_key
     ulid1_1 = ULID.parse('01ARZ3NDEKTSV4RRFFQ69G5FAV')
     ulid1_2 = ULID.parse('01ARZ3NDEKTSV4RRFFQ69G5FAV')

--- a/test/core/test_ulid_subclass.rb
+++ b/test/core/test_ulid_subclass.rb
@@ -39,6 +39,41 @@ class TestULIDSubClass < Test::Unit::TestCase
     end
   end
 
+  def test_comparisons_do_not_return_true_even_if_same_value_except_object_identifier
+    ulid1 = ULID.generate
+    ulid2 = ULID.generate
+    ulid1_sub = Subclass.parse(ulid1.to_s)
+
+    # This is an exception for comparison. Because same checks different objects
+    assert_equal(false, ulid1.equal?(ulid1_sub))
+    assert_equal(false, ulid1_sub.equal?(ulid1))
+
+    # This should return false. Because having different value
+    assert_equal(false, ulid2 == ulid1_sub)
+    assert_equal(false, ulid1_sub == ulid2)
+    assert_equal(false, ulid2.eql?(ulid1_sub))
+    assert_equal(false, ulid1_sub.eql?(ulid2))
+
+    assert_equal(true, ulid1 == ulid1_sub)
+    assert_equal(true, ulid1_sub == ulid1)
+    assert_equal(true, ulid1.eql?(ulid1_sub))
+    assert_equal(true, ulid1_sub.eql?(ulid1))
+
+    assert_equal(ulid1.hash, ulid1_sub.hash)
+    assert_not_equal(ulid2.hash, ulid1_sub.hash)
+
+    hash = {
+      ulid1 => :ulid1,
+      ulid1_sub => :ulid1_sub,
+      ulid2 => :ulid2
+    }
+
+    assert_equal([:ulid1_sub, :ulid2], hash.values)
+    assert_equal(:ulid1_sub, hash.fetch(ulid1))
+    assert_equal(:ulid1_sub, hash.fetch(ulid1_sub))
+    assert_equal(:ulid2, hash.fetch(ulid2))
+  end
+
   def test_succ_pred_returns_original_class
     instance = Subclass.parse('01ARZ3NDEKTSV4RRFFQ69G5FAV')
     assert_instance_of(ULID, instance.succ)


### PR DESCRIPTION
New way is clasic style. e.g https://github.com/kachick/hash-keyable/blob/ad312f72822c655cbc7a9908808b26c4da5c862a/lib/hash/keyable.rb#L33-L35

I don't have confident which is better way for this class...🤔 