### PR TITLE
Implement ULID.valid_as_variants? with ULID.valid? deprecation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
   },
   "ruby.format": "rubocop",
   "cSpell.words": [
+    "kwargs",
     "Undocumentable",
     "unshareable"
   ] // use rubocop for formatting

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ The original `Crockford's base32` maps `I`, `L` to `1`, `O` to `0`.
 And accepts freestyle inserting `Hyphens (-)`.
 To consider this patterns or not is different in each implementations.
 
-Current parser/validator/matcher aims to cover `subset of Crockford's base32`.
+Current parser/validator/matcher basically aims to cover `subset of Crockford's base32`.
 I have suggested it would be clarified in [ulid/spec#57](https://github.com/ulid/spec/pull/57).
 
 >Case insensitive
@@ -356,12 +356,13 @@ But it is a controversial point, discussing in [ulid/spec#3](https://github.com/
 
 Be that as it may, this gem provides API for handling the nasty possibilities.
 
-`ULID.normalize` and `ULID.normalized?`
+`ULID.normalize`, `ULID.normalized?`, `ULID.valid_as_variants?`
 
 ```ruby
-ULID.normalize('-olarz3-noekisv4rrff-q6ig5fav--') #=> "01ARZ3N0EK1SV4RRFFQ61G5FAV"
-ULID.normalized?('-olarz3-noekisv4rrff-q6ig5fav--') #=> false
-ULID.normalized?('01ARZ3N0EK1SV4RRFFQ61G5FAV') #=> true
+ULID.normalize('01g70y0y7g-z1xwdarexergsddd') #=> "01G70Y0Y7GZ1XWDAREXERGSDDD"
+ULID.normalized?('01g70y0y7g-z1xwdarexergsddd') #=> false
+ULID.normalized?('01G70Y0Y7GZ1XWDAREXERGSDDD') #=> true
+ULID.valid_as_variants?('01g70y0y7g-z1xwdarexergsddd') #=> true
 ```
 
 #### UUIDv4 converter (experimental)

--- a/lib/ulid.rb
+++ b/lib/ulid.rb
@@ -280,18 +280,36 @@ class ULID
     parse(normalized_in_crockford).to_s
   end
 
+  # @param [String, #to_str] string
   # @return [Boolean]
-  def self.normalized?(object)
-    normalized = normalize(object)
+  def self.normalized?(string)
+    normalized = normalize(string)
   rescue Exception
     false
   else
-    normalized == object
+    normalized == string
   end
 
+  # @param [String, #to_str] string
   # @return [Boolean]
-  def self.valid?(object)
-    string = String.try_convert(object)
+  def self.valid_as_variants?(string)
+    normalize(string)
+  rescue Exception
+    false
+  else
+    true
+  end
+
+  # @deprecated Use [.valid_as_variants?] or [.normalized?] instead
+  #
+  # Returns `true` if it is normalized string.
+  # Basically the difference of normalized? is to accept downcase or not. This returns true for downcased ULIDs.
+  #
+  # @return [Boolean]
+  def self.valid?(string)
+    warn_kwargs = (RUBY_VERSION >= '3.0') ? { category: :deprecated } : {}
+    Warning.warn('ULID.valid? is deprecated. Use ULID.valid_as_variants? or ULID.normalized? instead.', **warn_kwargs)
+    string = String.try_convert(string)
     string ? STRICT_PATTERN_WITH_CROCKFORD_BASE32_SUBSET.match?(string) : false
   end
 

--- a/sig/ulid.rbs
+++ b/sig/ulid.rbs
@@ -309,14 +309,13 @@ class ULID < Object
   # ```
   def self.sample: (?period: period) -> ULID
                  | (Integer number, ?period: period?) -> Array[ULID]
-  def self.valid?: (untyped) -> bool
 
   # Returns normalized string
   #
   # ```ruby
+  # ULID.normalize('01G70Y0Y7G-Z1XWDAREXERGSDDD') #=> "01G70Y0Y7GZ1XWDAREXERGSDDD"
   # ULID.normalize('-olarz3-noekisv4rrff-q6ig5fav--') #=> "01ARZ3N0EK1SV4RRFFQ61G5FAV"
-  # ULID.normalized?('-olarz3-noekisv4rrff-q6ig5fav--') #=> false
-  # ULID.normalized?('01ARZ3N0EK1SV4RRFFQ61G5FAV') #=> true
+  # ULID.normalize('01G70Y0Y7G_Z1XWDAREXERGSDDD') #=> ULID::ParserError
   # ```
   #
   # See also [ulid/spec#57](https://github.com/ulid/spec/pull/57) and [ulid/spec#3](https://github.com/ulid/spec/issues/3)
@@ -325,13 +324,40 @@ class ULID < Object
   # Returns `true` if it is normalized string
   #
   # ```ruby
-  # ULID.normalize('-olarz3-noekisv4rrff-q6ig5fav--') #=> "01ARZ3N0EK1SV4RRFFQ61G5FAV"
-  # ULID.normalized?('-olarz3-noekisv4rrff-q6ig5fav--') #=> false
-  # ULID.normalized?('01ARZ3N0EK1SV4RRFFQ61G5FAV') #=> true
+  # ULID.normalized?('01G70Y0Y7GZ1XWDAREXERGSDDD') #=> true
+  # ULID.normalized?('01G70Y0Y7G-Z1XWDAREXERGSDDD') #=> false
+  # ULID.normalized?(ULID.generate.to_s.downcase) #=> false
+  # ULID.normalized?('01G70Y0Y7G_Z1XWDAREXERGSDDD') #=> false (Not raising ULID::ParserError)
   # ```
   #
   # See also [ulid/spec#57](https://github.com/ulid/spec/pull/57) and [ulid/spec#3](https://github.com/ulid/spec/issues/3)
-  def self.normalized?: (untyped) -> bool
+  def self.normalized?: (_ToStr string) -> bool
+                      | (untyped) -> false
+
+  # Returns `true` if it is valid in ULID format variants
+  #
+  # ```ruby
+  # ULID.valid_as_variants?(ULID.generate.to_s.downcase) #=> true
+  # ULID.valid_as_variants?('01G70Y0Y7G-Z1XWDAREXERGSDDD') #=> true
+  # ULID.valid_as_variants?('01G70Y0Y7G_Z1XWDAREXERGSDDD') #=> false
+  # ```
+  #
+  # See also [ulid/spec#57](https://github.com/ulid/spec/pull/57) and [ulid/spec#3](https://github.com/ulid/spec/issues/3)
+  def self.valid_as_variants?: (_ToStr string) -> bool
+                             | (untyped) -> false
+
+  # DEPRECATED Use valid_as_variants? instead
+  #
+  # Returns `true` if it is normalized string.
+  # Basically the difference of normalized? is to accept downcase or not. This returns true for downcased ULIDs.
+  #
+  # ```ruby
+  # ULID.valid?(ULID.generate.to_s.downcase) #=> true
+  # ```
+  #
+  # See also [ulid/spec#57](https://github.com/ulid/spec/pull/57) and [ulid/spec#3](https://github.com/ulid/spec/issues/3)
+  def self.valid?: (_ToStr string) -> bool
+                 | (untyped) -> false
 
   # Returns parsed ULIDs from given String for rough operations.
   #

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -1,1 +1,13 @@
---- []
+---
+- file: lib/ulid.rb
+  diagnostics:
+  - range:
+      start:
+        line: 311
+        character: 12
+      end:
+        line: 311
+        character: 16
+    severity: ERROR
+    message: Type `singleton(::Warning)` does not have method `warn`
+    code: Ruby::NoMethod

--- a/test/many_data/test_fixed_many_data.rb
+++ b/test/many_data/test_fixed_many_data.rb
@@ -25,7 +25,7 @@ class TestFixedManyData < Test::Unit::TestCase
     assert_equal(example.octets, ulid.octets)
 
     assert do
-      ULID.valid?(example.string)
+      ULID.normalized?(example.string)
     end
   end
 


### PR DESCRIPTION
ref: #57 #143, #78