### PR TITLE
Prefer String#tr for other crockford features

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,13 +99,21 @@ ULID.generate(moment: time) #=> ULID(2000-01-01 00:00:00.000 UTC: 00VHNCZB006WQT
 ULID.at(time) #=> ULID(2000-01-01 00:00:00.000 UTC: 00VHNCZB002W5BGWWKN76N22H6)
 ```
 
-Also `ULID.encode` can be used if you just want to get strings.  
-It returns [normalized](#variants-of-format) String without ULID object creation.  
+Also `ULID.encode` and `ULID.decode_time` can be used to get primitive values for most usecases.  
+
+`ULID.encode` returns [normalized](#variants-of-format) String without ULID object creation.  
 It can take same arguments as `ULID.generate`.
 
 ```ruby
 ULID.encode #=> "01G86M42Q6SJ9XQM2ZRM6JRDSF"
 ULID.encode(moment: Time.at(946684800).utc) #=> "00VHNCZB00SYG7RCEXZC9DA4E1"
+```
+
+`ULID.decode_time` returns Time. It can take `in` keyarg as same as `Time.at`.
+
+```ruby
+ULID.decode_time('00VHNCZB00SYG7RCEXZC9DA4E1') #=> 2000-01-01 00:00:00 UTC
+ULID.decode_time('00VHNCZB00SYG7RCEXZC9DA4E1', in: '+09:00') #=> 2000-01-01 09:00:00 +0900
 ```
 
 ### Sortable with the timestamp

--- a/README.md
+++ b/README.md
@@ -116,6 +116,16 @@ ULID.decode_time('00VHNCZB00SYG7RCEXZC9DA4E1') #=> 2000-01-01 00:00:00 UTC
 ULID.decode_time('00VHNCZB00SYG7RCEXZC9DA4E1', in: '+09:00') #=> 2000-01-01 09:00:00 +0900
 ```
 
+This project does not prioritize the speed. However it actually works faster than others! :zap:
+
+Snapshot on 0.6.0.pre is below
+
+* Generator is 1.4x faster than - [ulid gem](https://github.com/rafaelsales/ulid)
+* Generator is 1.7x faster than - [ulid-ruby gem](https://github.com/abachman/ulid-ruby)
+* Parser is 2.6x faster than - [ulid-ruby gem](https://github.com/abachman/ulid-ruby)
+
+You can see further detail at [Benchmark](https://github.com/kachick/ruby-ulid/wiki/Benchmark).
+
 ### Sortable with the timestamp
 
 ULIDs are sortable when they are generated in different timestamp with milliseconds precision.

--- a/Rakefile
+++ b/Rakefile
@@ -101,6 +101,7 @@ task(:benchmark_with_other_gems) do
       cd("./benchmark/compare_with_othergems/#{author}") do
         sh('bundle install --quiet')
         sh('bundle exec ruby -v ./generate.rb')
+        sh('bundle exec ruby -v ./parser.rb')
       end
     end
   end

--- a/benchmark/compare_with_othergems/abachman/parser.rb
+++ b/benchmark/compare_with_othergems/abachman/parser.rb
@@ -1,0 +1,20 @@
+# coding: utf-8
+# frozen_string_literal: true
+
+require('benchmark/ips')
+require('ulid')
+
+raise("Bug to setup: #{ULID.methods(false)}") unless ULID.const_defined?(:Identifier)
+
+example_encoded_string = '01F4A5Y1YAQCYAYCTC7GRMJ9AA'
+products = []
+
+Benchmark.ips do |x|
+  x.report('ULID.time') do
+    products << ULID.time(example_encoded_string)
+  end
+end
+
+# Below sections ensuring basic behaviors
+
+p("`ulid-ruby gem - #{ULID::VERSION}` generated products: #{products.size} - sample: #{products.sample(5)}")

--- a/benchmark/compare_with_othergems/kachick/parser.rb
+++ b/benchmark/compare_with_othergems/kachick/parser.rb
@@ -1,0 +1,20 @@
+# coding: utf-8
+# frozen_string_literal: true
+
+require('benchmark/ips')
+require('ulid')
+
+raise("Bug to setup: #{ULID.methods(false)}") unless ULID.const_defined?(:MonotonicGenerator)
+
+example_encoded_string = '01F4A5Y1YAQCYAYCTC7GRMJ9AA'
+products = []
+
+Benchmark.ips do |x|
+  x.report('ULID.decode_time') do
+    products << ULID.decode_time(example_encoded_string)
+  end
+end
+
+# Below sections ensuring basic behaviors
+
+p("`ruby-ulid gem (this one) - #{ULID::VERSION}` generated products: #{products.size} - sample: #{products.sample(5)}")

--- a/benchmark/compare_with_othergems/rafaelsales/parser.rb
+++ b/benchmark/compare_with_othergems/rafaelsales/parser.rb
@@ -1,0 +1,9 @@
+# coding: utf-8
+# frozen_string_literal: true
+
+require('benchmark/ips')
+require('ulid')
+
+raise("Bug to setup: #{ULID.methods(false)}") unless ULID.const_defined?(:Generator)
+
+p("`ulid gem - #{ULID::VERSION}` does not have parsers yet")

--- a/benchmark/parsers.rb
+++ b/benchmark/parsers.rb
@@ -10,6 +10,7 @@ encoded = sample.to_s
 
 Benchmark.ips do |x|
   x.report('ULID.parse') { ULID.parse(encoded) }
+  x.report('ULID.decode_time') { ULID.decode_time(encoded) }
   x.report('ULID.from_integer') { ULID.from_integer(fixed_integer) }
   x.compare!
 end

--- a/lib/ulid.rb
+++ b/lib/ulid.rb
@@ -6,6 +6,11 @@
 
 require('securerandom')
 
+require_relative('ulid/version')
+require_relative('ulid/errors')
+require_relative('ulid/crockford_base32')
+require_relative('ulid/monotonic_generator')
+
 # @see https://github.com/ulid/spec
 # @!attribute [r] milliseconds
 #   @return [Integer]
@@ -13,16 +18,6 @@ require('securerandom')
 #   @return [Integer]
 class ULID
   include(Comparable)
-
-  class Error < StandardError; end
-  class OverflowError < Error; end
-  class ParserError < Error; end
-  class UnexpectedError < Error; end
-
-  # Excluded I, L, O, U, -.
-  # This is the encoding patterns.
-  # The decoding issue is written in ULID::CrockfordBase32
-  CROCKFORD_BASE32_ENCODING_STRING = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
 
   TIMESTAMP_ENCODED_LENGTH = 10
   RANDOMNESS_ENCODED_LENGTH = 16
@@ -38,12 +33,12 @@ class ULID
 
   # @see https://github.com/ulid/spec/pull/57
   # Currently not used as a constant, but kept as a reference for now.
-  PATTERN_WITH_CROCKFORD_BASE32_SUBSET = /(?<timestamp>[0-7][#{CROCKFORD_BASE32_ENCODING_STRING}]{#{TIMESTAMP_ENCODED_LENGTH - 1}})(?<randomness>[#{CROCKFORD_BASE32_ENCODING_STRING}]{#{RANDOMNESS_ENCODED_LENGTH}})/i.freeze
+  PATTERN_WITH_CROCKFORD_BASE32_SUBSET = /(?<timestamp>[0-7][#{CrockfordBase32::ENCODING_STRING}]{#{TIMESTAMP_ENCODED_LENGTH - 1}})(?<randomness>[#{CrockfordBase32::ENCODING_STRING}]{#{RANDOMNESS_ENCODED_LENGTH}})/i.freeze
 
   STRICT_PATTERN_WITH_CROCKFORD_BASE32_SUBSET = /\A#{PATTERN_WITH_CROCKFORD_BASE32_SUBSET.source}\z/i.freeze
 
   # Optimized for `ULID.scan`, might be changed the definition with gathered `ULID.scan` spec changed.
-  SCANNING_PATTERN = /\b[0-7][#{CROCKFORD_BASE32_ENCODING_STRING}]{#{TIMESTAMP_ENCODED_LENGTH - 1}}[#{CROCKFORD_BASE32_ENCODING_STRING}]{#{RANDOMNESS_ENCODED_LENGTH}}\b/i.freeze
+  SCANNING_PATTERN = /\b[0-7][#{CrockfordBase32::ENCODING_STRING}]{#{TIMESTAMP_ENCODED_LENGTH - 1}}[#{CrockfordBase32::ENCODING_STRING}]{#{RANDOMNESS_ENCODED_LENGTH}}\b/i.freeze
 
   # Similar as Time#inspect since Ruby 2.7, however it is NOT same.
   # Time#inspect trancates needless digits. Keeping full milliseconds with "%3N" will fit for ULID.
@@ -603,12 +598,9 @@ class ULID
   end
 end
 
-require_relative('ulid/version')
-require_relative('ulid/crockford_base32')
-require_relative('ulid/monotonic_generator')
 require_relative('ulid/ractor_unshareable_constants')
 
 class ULID
   # Do not write as `ULID.private_constant` for avoiding YARD warnings `[warn]: in YARD::Handlers::Ruby::PrivateConstantHandler: Undocumentable private constants:`
-  private_constant(:TIME_FORMAT_IN_INSPECT, :MIN, :MAX, :RANDOM_INTEGER_GENERATOR, :CROCKFORD_BASE32_ENCODING_STRING)
+  private_constant(:TIME_FORMAT_IN_INSPECT, :MIN, :MAX, :RANDOM_INTEGER_GENERATOR)
 end

--- a/lib/ulid/errors.rb
+++ b/lib/ulid/errors.rb
@@ -1,0 +1,10 @@
+# coding: us-ascii
+# frozen_string_literal: true
+# shareable_constant_value: literal
+
+class ULID
+  class Error < StandardError; end
+  class OverflowError < Error; end
+  class ParserError < Error; end
+  class UnexpectedError < Error; end
+end

--- a/sig/ulid.rbs
+++ b/sig/ulid.rbs
@@ -1,6 +1,5 @@
 class ULID < Object
   VERSION: String
-  CROCKFORD_BASE32_ENCODING_STRING: String
   TIMESTAMP_ENCODED_LENGTH: 10
   RANDOMNESS_ENCODED_LENGTH: 16
   ENCODED_LENGTH: 26
@@ -39,13 +38,16 @@ class ULID < Object
     class SetupError < UnexpectedError
     end
 
+    ENCODING_STRING: String
+    ORDERED_CROCKFORD_BASE32_CHARS: Array[String]
+    ORDERED_N32_CHARS: Array[String]
     N32_CHAR_BY_CROCKFORD_BASE32_CHAR: Hash[String, String]
     CROCKFORD_BASE32_CHAR_PATTERN: Regexp
     CROCKFORD_BASE32_CHAR_BY_N32_CHAR: Hash[String, String]
-    ORDERED_CROCKFORD_BASE32_CHARS: String
-    ORDERED_N32_CHARS: String
-    STANDARD_BY_VARIANT: Hash[String, String]
-    VARIANT_PATTERN: Regexp
+    CROCKFORD_BASE32_TR_PATTERN: String
+    N32_TR_PATTERN: String
+    VARIANT_TR_PATTERN: String
+    NORMALIZED_TR_PATTERN: String
 
     # A private API. Should not be used in your code.
     def self.encode: (Integer integer) -> String

--- a/sig/ulid.rbs
+++ b/sig/ulid.rbs
@@ -157,6 +157,8 @@ class ULID < Object
   # Retuns encoded and normalzied String.
   # It has same arguments signatures as `.generate`. So can be used for just ID creation usecases without needless object creation.
   #
+  # NOTE: Difference of ULID#encode, returned String is NOT frozen.
+  #
   def self.encode: (?moment: moment, ?entropy: Integer) -> String
 
   # A private API. Should not be used in your code.
@@ -222,13 +224,24 @@ class ULID < Object
   # ```
   def self.floor: (Time time) -> Time
 
-  # Get ULID instance from encoded String.
+  # Return ULID instance from encoded String.
   #
   # ```ruby
   # ulid = ULID.parse('01ARZ3NDEKTSV4RRFFQ69G5FAV')
   # #=> ULID(2016-07-30 23:54:10.259 UTC: 01ARZ3NDEKTSV4RRFFQ69G5FAV)
   # ```
   def self.parse: (_ToStr string) -> ULID
+
+  # Return Time instance from encoded String.
+  # See also `ULID.encode` for similar purpose.
+  #
+  # NOTE: Difference of ULID#to_time, returned Time is NOT frozen.
+  #
+  # ```ruby
+  # time = ULID.decode_time('01ARZ3NDEKTSV4RRFFQ69G5FAV')
+  # #=> 2016-07-30 23:54:10.259 UTC
+  # ```
+  def self.decode_time: (_ToStr string, ?in: String | Integer | nil) -> Time
 
   # Get ULID instance from unnormalized String that encoded in Crockford's base32.
   #

--- a/test/many_data/test_randomized_many_data.rb
+++ b/test/many_data/test_randomized_many_data.rb
@@ -20,12 +20,28 @@ class TestManyData < Test::Unit::TestCase
     assert_not_equal(ulids, ulids.sort_by(&:to_s))
   end
 
+  def test_encode
+    ulid_strings = 1000.times.map do |n|
+      if (n % 100).zero?
+        sleep(0.01)
+      end
+
+      ULID.encode
+    end
+
+    assert_equal(1000, ulid_strings.uniq.size)
+    assert_equal(true, (5..50).cover?(ulid_strings.map { |str| ULID.parse(str) }.group_by(&:to_time).size))
+    assert_not_equal(ulid_strings, ulid_strings.sort)
+  end
+
   def test_string_format_and_reversible
     ULID.sample(10000).each do |ulid|
       assert_equal(ULID::ENCODED_LENGTH, ulid.to_s.size)
       assert_equal(ULID::ENCODED_LENGTH, ulid.to_s.bytesize)
       assert_equal(ulid.to_s, ULID.parse(ulid.to_s).to_s)
       assert_equal(ulid.to_s, ULID.parse(ulid.to_s.downcase).to_s)
+      assert_equal(ULID.parse(ulid.to_s).to_time, ULID.decode_time(ulid.to_s))
+      assert_equal(ULID.parse(ulid.to_s).to_time, ULID.decode_time(ulid.to_s.downcase))
     end
   end
 


### PR DESCRIPTION
ref: #213, #102

⚡ This PR makes 2.5x faster parser.

Before
---

```
❯ rake benchmark/parsers.rb
/home/kachick/.rubies/ruby-3.1.2/bin/ruby benchmark/parsers.rb
Warming up --------------------------------------
          ULID.parse     9.091k i/100ms
   ULID.from_integer    39.356k i/100ms
Calculating -------------------------------------
          ULID.parse     91.248k (± 5.4%) i/s -    463.641k in   5.097270s
   ULID.from_integer    391.392k (± 2.7%) i/s -      1.968M in   5.031541s

Comparison:
   ULID.from_integer:   391392.3 i/s
          ULID.parse:    91247.8 i/s - 4.29x  (± 0.00) slower
```

After
---

```
❯ rake benchmark/parsers.rb
/home/kachick/.rubies/ruby-3.1.2/bin/ruby benchmark/parsers.rb
Warming up --------------------------------------
          ULID.parse    20.964k i/100ms
    ULID.decode_time    24.609k i/100ms
   ULID.from_integer    34.517k i/100ms
Calculating -------------------------------------
          ULID.parse    210.466k (± 3.7%) i/s -      1.069M in   5.087177s
    ULID.decode_time    258.681k (± 4.7%) i/s -      1.304M in   5.054055s
   ULID.from_integer    335.660k (± 4.1%) i/s -      1.691M in   5.047816s

Comparison:
   ULID.from_integer:   335660.4 i/s
    ULID.decode_time:   258680.8 i/s - 1.30x  (± 0.00) slower
          ULID.parse:   210466.0 i/s - 1.59x  (± 0.00) slower
```

```
❯ rake benchmark_with_other_gems
------------------------------------------------------------------------
#### kachick - ruby-ulid(This one)
cd ./benchmark/compare_with_othergems/kachick
bundle install --quiet
bundle exec ruby -v ./parser.rb
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-linux]
Warming up --------------------------------------
    ULID.decode_time    16.458k i/100ms
Calculating -------------------------------------
    ULID.decode_time    160.777k (±32.3%) i/s -    740.610k in   5.134636s
"`ruby-ulid gem (this one) - 0.6.0.pre` generated products: 1052719 - sample: [2021-04-27 17:27:22.826 UTC, 2021-04-27 17:27:22.826 UTC, 2021-04-27 17:27:22.826 UTC, 2021-04-27 17:27:22.826 UTC, 2021-04-27 17:27:22.826 UTC]"
cd -
------------------------------------------------------------------------
#### rafaelsales - ulid
cd ./benchmark/compare_with_othergems/rafaelsales
bundle install --quiet
bundle exec ruby -v ./parser.rb
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-linux]
"`ulid gem - 1.3.0` does not have parsers yet"
cd -
------------------------------------------------------------------------
#### abachman - ulid-ruby
cd ./benchmark/compare_with_othergems/abachman
bundle install --quiet
bundle exec ruby -v ./parser.rb
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-linux]
Warming up --------------------------------------
           ULID.time     5.826k i/100ms
Calculating -------------------------------------
           ULID.time     60.871k (±13.4%) i/s -    302.952k in   5.077365s
"`ulid-ruby gem - 1.0.2` generated products: 417283 - sample: [2021-04-27 17:27:22.826 UTC, 2021-04-27 17:27:22.826 UTC, 2021-04-27 17:27:22.826 UTC, 2021-04-27 17:27:22.826 UTC, 2021-04-27 17:27:22.826 UTC]"
cd -
```
