### PR TITLE
Use minimum tr patterns

### DIFF
--- a/lib/ulid/crockford_base32.rb
+++ b/lib/ulid/crockford_base32.rb
@@ -15,8 +15,7 @@ class ULID
   #   * https://github.com/kachick/ruby-ulid/issues/57
   #   * https://github.com/kachick/ruby-ulid/issues/78
   module CrockfordBase32
-    # Excluded I, L, O, U, - from Base32
-    base32_to_crockford = {
+    same_definitions = {
       '0' => '0',
       '1' => '1',
       '2' => '2',
@@ -34,7 +33,11 @@ class ULID
       'E' => 'E',
       'F' => 'F',
       'G' => 'G',
-      'H' => 'H',
+      'H' => 'H'
+    }.freeze
+
+    # Excluded I, L, O, U, - from Base32
+    base32_to_crockford = {
       'I' => 'J',
       'J' => 'K',
       'K' => 'M',
@@ -51,7 +54,8 @@ class ULID
       'V' => 'Z'
     }.freeze
     BASE32_TR_PATTERN = base32_to_crockford.keys.join.freeze
-    ENCODING_STRING = CROCKFORD_TR_PATTERN = base32_to_crockford.values.join.freeze
+    CROCKFORD_TR_PATTERN = base32_to_crockford.values.join.freeze
+    ENCODING_STRING = "#{same_definitions.values.join}#{CROCKFORD_TR_PATTERN}".freeze
 
     variant_to_normarized = {
       'L' => '1',


### PR DESCRIPTION
ref: #102, @213, #216

This change improves performance a bit.

Before

```
/home/kachick/.rubies/ruby-3.1.2/bin/ruby benchmark/generate_vs_encode.rb
Warming up --------------------------------------
  ULID.generate.to_s    12.384k i/100ms
         ULID.encode    14.904k i/100ms
Calculating -------------------------------------
  ULID.generate.to_s    128.537k (± 1.1%) i/s -    643.968k in   5.010647s
         ULID.encode    147.112k (± 1.6%) i/s -    745.200k in   5.066891s

Comparison:
         ULID.encode:   147112.0 i/s
  ULID.generate.to_s:   128537.1 i/s - 1.14x  (± 0.00) slower

/home/kachick/.rubies/ruby-3.1.2/bin/ruby benchmark/parsers.rb
Warming up --------------------------------------
          ULID.parse    23.324k i/100ms
    ULID.decode_time    27.101k i/100ms
   ULID.from_integer    39.544k i/100ms
Calculating -------------------------------------
          ULID.parse    239.009k (± 0.7%) i/s -      1.213M in   5.074778s
    ULID.decode_time    281.062k (± 1.2%) i/s -      1.409M in   5.014783s
   ULID.from_integer    403.776k (± 0.5%) i/s -      2.056M in   5.092766s

Comparison:
   ULID.from_integer:   403775.6 i/s
    ULID.decode_time:   281062.0 i/s - 1.44x  (± 0.00) slower
          ULID.parse:   239008.6 i/s - 1.69x  (± 0.00) slower
```


After

```
/home/kachick/.rubies/ruby-3.1.2/bin/ruby benchmark/generate_vs_encode.rb
Warming up --------------------------------------
  ULID.generate.to_s    13.968k i/100ms
         ULID.encode    16.417k i/100ms
Calculating -------------------------------------
  ULID.generate.to_s    137.708k (± 2.7%) i/s -    698.400k in   5.075819s
         ULID.encode    157.262k (± 5.1%) i/s -    788.016k in   5.024994s

Comparison:
         ULID.encode:   157262.2 i/s
  ULID.generate.to_s:   137707.7 i/s - 1.14x  (± 0.00) slower

/home/kachick/.rubies/ruby-3.1.2/bin/ruby benchmark/parsers.rb
Warming up --------------------------------------
          ULID.parse    27.709k i/100ms
    ULID.decode_time    30.215k i/100ms
   ULID.from_integer    45.754k i/100ms
Calculating -------------------------------------
          ULID.parse    280.413k (± 2.1%) i/s -      1.413M in   5.041811s
    ULID.decode_time    297.517k (± 5.3%) i/s -      1.511M in   5.097710s
   ULID.from_integer    453.802k (± 1.3%) i/s -      2.288M in   5.042069s

Comparison:
   ULID.from_integer:   453801.8 i/s
    ULID.decode_time:   297516.8 i/s - 1.53x  (± 0.00) slower
          ULID.parse:   280412.9 i/s - 1.62x  (± 0.00) slower

```