### PR TITLE
Backport refactoring part from experimental PR

### DIFF
--- a/lib/ulid/monotonic_generator.rb
+++ b/lib/ulid/monotonic_generator.rb
@@ -14,7 +14,8 @@ class ULID
     include(MonitorMixin)
 
     # @return [ULID, nil]
-    attr_reader(:prev)
+    attr_accessor(:prev)
+    private(:prev=)
 
     undef_method(:instance_variable_set)
 
@@ -71,6 +72,9 @@ class ULID
       end
     end
 
+    # Just providing similar api as `ULID.generate` and `ULID.encode` relation. No performance benefit exists in monotonic generator's one.
+    #
+    # @see https://github.com/kachick/ruby-ulid/pull/220
     # @param [Time, Integer] moment
     # @return [String]
     def encode(moment: Utils.current_milliseconds)

--- a/sig/ulid.rbs
+++ b/sig/ulid.rbs
@@ -19,8 +19,8 @@ class ULID < Object
   MAX: ULID
   include Comparable
 
-  # The `moment` is a `Time` or `Intger of the milliseconds`
-  type moment = Time | Integer
+  type milliseconds = Integer
+  type moment = Time | milliseconds
 
   class Error < StandardError
   end
@@ -36,15 +36,15 @@ class ULID < Object
 
   # Private module
   module Utils
-    def self.encode_base32: (milliseconds: Integer, entropy: Integer) -> String
+    def self.encode_base32: (milliseconds: milliseconds, entropy: Integer) -> String
 
-    def self.current_milliseconds: -> Integer
+    def self.current_milliseconds: -> milliseconds
 
-    def self.milliseconds_from_moment: (moment moment) -> Integer
+    def self.milliseconds_from_moment: (moment moment) -> milliseconds
 
     def self.reasonable_entropy: -> Integer
 
-    def self.milliseconds_from_time: (Time time) -> Integer
+    def self.milliseconds_from_time: (Time time) -> milliseconds
 
     def self.safe_get_class_name: (untyped object) -> String
   end
@@ -105,6 +105,8 @@ class ULID < Object
     private
 
     def initialize: -> void
+
+    def prev=: (ULID?) -> void
   end
 
   interface _ToULID
@@ -608,7 +610,7 @@ class ULID < Object
 
   private
 
-  def initialize: (milliseconds: Integer, entropy: Integer, integer: Integer, encoded: String) -> void
+  def initialize: (milliseconds: milliseconds, entropy: Integer, integer: Integer, encoded: String) -> void
 
   def cache_all_instance_variables: -> void
 end

--- a/test/concurrency/test_ulid_monotonic_generator_thread_safety.rb
+++ b/test/concurrency/test_ulid_monotonic_generator_thread_safety.rb
@@ -86,9 +86,7 @@ class TestULIDMonotonicGeneratorThreadSafety < Test::Unit::TestCase
     thread_count = 3000
     initial_and_median = ULID.generate
 
-    generator.instance_exec do
-      @prev = initial_and_median
-    end
+    generator.__send__(:prev=, initial_and_median)
 
     # Given smaller than initial should not be happened... But added for ensuring https://github.com/kachick/ruby-ulid/issues/56
     sample_1000_times_before_median = ULID.sample(1000, period: (initial_and_median.to_time - 999999)..initial_and_median.to_time).map(&:to_time)

--- a/test/core/test_ulid_monotonic_generator.rb
+++ b/test/core/test_ulid_monotonic_generator.rb
@@ -139,22 +139,28 @@ class TestULIDMonotonicGenerator < Test::Unit::TestCase
   def test_generate_raises_overflow_when_called_on_max_entropy
     max_ulid_in_a_milliseconds = ULID.max(Time.now)
 
-    @generator.instance_exec do
-      @prev = max_ulid_in_a_milliseconds.pred
-    end
+    @generator.__send__(:prev=, max_ulid_in_a_milliseconds.pred)
 
     assert_equal(max_ulid_in_a_milliseconds, @generator.generate(moment: max_ulid_in_a_milliseconds.milliseconds))
 
-    @generator.instance_exec do
-      @prev = nil
-    end
-
-    @generator.instance_exec do
-      @prev = max_ulid_in_a_milliseconds
-    end
+    @generator.__send__(:prev=, max_ulid_in_a_milliseconds)
 
     assert_raises(ULID::OverflowError) do
       @generator.generate(moment: max_ulid_in_a_milliseconds.milliseconds)
+    end
+  end
+
+  def test_encode_raises_overflow_when_called_on_max_entropy
+    max_ulid_in_a_milliseconds = ULID.max(Time.now)
+
+    @generator.__send__(:prev=, max_ulid_in_a_milliseconds.pred)
+
+    assert_equal(max_ulid_in_a_milliseconds.encode, @generator.encode(moment: max_ulid_in_a_milliseconds.milliseconds))
+
+    @generator.__send__(:prev=, max_ulid_in_a_milliseconds)
+
+    assert_raises(ULID::OverflowError) do
+      @generator.encode(moment: max_ulid_in_a_milliseconds.milliseconds)
     end
   end
 


### PR DESCRIPTION
Closes #220

I have tried to avoid object creation in MonotonicGenerator as #220. However it made **SLOWER** than now 🐌 
And the current speed is acceptable. So I would just backport some refactoring code. 👋 