### PR TITLE
Drop lazy caching

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,8 +121,8 @@ $ bundle exec ruby benchmark/the_added_file.rb
 
 ### Adding `ULID` instance variables
 
-- Basically should be reduced. ref: [#91](https://github.com/kachick/ruby-ulid/issues/91)
-- When having some objects, they should be frozen. ref: [#126](https://github.com/kachick/ruby-ulid/pull/126)
+- Basically should be reduced. ref: [#91](kachick/ruby-ulid#91), [#236](kachick/ruby-ulid#236)
+- When having some objects, they should be frozen. ref: [#126](kachick/ruby-ulid#126)
 
 ## Tasks to drop Ruby 2.7.x
 

--- a/lib/ulid.rb
+++ b/lib/ulid.rb
@@ -431,6 +431,7 @@ class ULID
   end
 
   # @return [Time]
+  # @param [String, Integer, nil] in
   def to_time(in: 'UTC')
     Time.at(0, @milliseconds, :millisecond, in: binding.local_variable_get(:in))
   end

--- a/lib/ulid.rb
+++ b/lib/ulid.rb
@@ -359,11 +359,25 @@ class ULID
     end
   end
 
-  attr_reader(:milliseconds, :entropy)
+  attr_reader(:milliseconds, :entropy, :encoded)
+  protected(:encoded)
+
+  # @param [Integer] milliseconds
+  # @param [Integer] entropy
+  # @param [Integer] integer
+  # @param [String] encoded
+  # @return [void]
+  def initialize(milliseconds:, entropy:, integer:, encoded:)
+    # All arguments check should be done with each constructors, not here
+    @integer = integer
+    @encoded = encoded
+    @milliseconds = milliseconds
+    @entropy = entropy
+  end
 
   # @return [String]
   def encode
-    @encoded
+    @encoded.dup
   end
   alias_method(:to_s, :encode)
 
@@ -384,7 +398,7 @@ class ULID
 
   # @return [String]
   def inspect
-    @inspect ||= "ULID(#{to_time.strftime(TIME_FORMAT_IN_INSPECT)}: #{@encoded})".freeze
+    "ULID(#{to_time.strftime(TIME_FORMAT_IN_INSPECT)}: #{@encoded})"
   end
 
   # @return [Boolean]
@@ -417,8 +431,8 @@ class ULID
   end
 
   # @return [Time]
-  def to_time
-    @time ||= Time.at(0, @milliseconds, :millisecond, in: 'UTC').freeze
+  def to_time(in: 'UTC')
+    Time.at(0, @milliseconds, :millisecond, in: binding.local_variable_get(:in))
   end
 
   # @return [Array(Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer)]
@@ -442,12 +456,12 @@ class ULID
 
   # @return [String]
   def timestamp
-    @timestamp ||= (@encoded.slice(0, TIMESTAMP_ENCODED_LENGTH).freeze || raise(UnexpectedError))
+    @encoded.slice(0, TIMESTAMP_ENCODED_LENGTH) || raise(UnexpectedError)
   end
 
   # @return [String]
   def randomness
-    @randomness ||= (@encoded.slice(TIMESTAMP_ENCODED_LENGTH, RANDOMNESS_ENCODED_LENGTH).freeze || raise(UnexpectedError))
+    @encoded.slice(TIMESTAMP_ENCODED_LENGTH, RANDOMNESS_ENCODED_LENGTH) || raise(UnexpectedError)
   end
 
   # @note Providing for rough operations. The keys and values is not fixed.
@@ -489,13 +503,6 @@ class ULID
     end
   end
 
-  # @return [self]
-  def freeze
-    # Need to cache before freezing, because frozen objects can't assign instance variables
-    cache_all_instance_variables
-    super
-  end
-
   # @return [Integer]
   def marshal_dump
     @integer
@@ -509,7 +516,7 @@ class ULID
       integer: unmarshaled.to_i,
       milliseconds: unmarshaled.milliseconds,
       entropy: unmarshaled.entropy,
-      encoded: unmarshaled.to_s
+      encoded: unmarshaled.encoded
     )
   end
 
@@ -518,39 +525,7 @@ class ULID
     self
   end
 
-  # @return [self]
-  def dup
-    self
-  end
-
-  # @return [self]
-  def clone(freeze: true)
-    self
-  end
-
   undef_method(:instance_variable_set)
-
-  private
-
-  # @param [Integer] milliseconds
-  # @param [Integer] entropy
-  # @param [Integer] integer
-  # @param [String] encoded
-  # @return [void]
-  def initialize(milliseconds:, entropy:, integer:, encoded:)
-    # All arguments check should be done with each constructors, not here
-    @integer = integer
-    @encoded = encoded
-    @milliseconds = milliseconds
-    @entropy = entropy
-  end
-
-  # @return [void]
-  def cache_all_instance_variables
-    inspect
-    timestamp
-    randomness
-  end
 
   MIN = parse('00000000000000000000000000').freeze
   MAX = parse('7ZZZZZZZZZZZZZZZZZZZZZZZZZ').freeze

--- a/lib/ulid/utils.rb
+++ b/lib/ulid/utils.rb
@@ -89,14 +89,7 @@ class ULID
     def self.make_sharable_value(value)
       value.freeze
       if defined?(Ractor)
-        case value
-        when ULID, Time
-          if ractor_can_make_shareable_time?
-            Ractor.make_shareable(value)
-          end
-        else
-          Ractor.make_shareable(value)
-        end
+        Ractor.make_shareable(value)
       end
     end
 
@@ -106,10 +99,6 @@ class ULID
         value = mod.const_get(const_name)
         make_sharable_value(value)
       end
-    end
-
-    def self.ractor_can_make_shareable_time?
-      RUBY_VERSION >= '3.1'
     end
   end
 

--- a/lib/ulid/version.rb
+++ b/lib/ulid/version.rb
@@ -3,5 +3,5 @@
 # shareable_constant_value: literal
 
 class ULID
-  VERSION = '0.7.0'
+  VERSION = '0.8.0.pre'
 end

--- a/sig/ulid.rbs
+++ b/sig/ulid.rbs
@@ -170,8 +170,6 @@ class ULID < Object
   # Retuns encoded and normalzied String.
   # It has same arguments signatures as `.generate`. So can be used for just ID creation usecases without needless object creation.
   #
-  # NOTE: Difference of ULID#encode, returned String is NOT frozen.
-  #
   def self.encode: (?moment: moment, ?entropy: Integer) -> String
 
   # Shorthand of `ULID.generate(moment: Time)`
@@ -236,16 +234,18 @@ class ULID < Object
   # ```
   def self.parse: (_ToStr string) -> ULID
 
+  type time_in = String | Integer | nil
+
   # Return Time instance from encoded String.
   # See also `ULID.encode` for similar purpose.
-  #
-  # NOTE: Difference of ULID#to_time, returned Time is NOT frozen.
   #
   # ```ruby
   # time = ULID.decode_time('01ARZ3NDEKTSV4RRFFQ69G5FAV')
   # #=> 2016-07-30 23:54:10.259 UTC
+  # ULID.decode_time('01ARZ3NDEKTSV4RRFFQ69G5FAV', in: '+09:00')
+  # #=> 2016-07-31 08:54:10.259 +0900
   # ```
-  def self.decode_time: (_ToStr string, ?in: String | Integer | nil) -> Time
+  def self.decode_time: (_ToStr string, ?in: time_in) -> Time
 
   # Get ULID instance from unnormalized String that encoded in Crockford's base32.
   #
@@ -459,14 +459,16 @@ class ULID < Object
   # ulid.milliseconds #=> 1619544442826
   # ```
   attr_reader milliseconds: Integer
+
   attr_reader entropy: Integer
+
+  # Private api. (Actually defined protected visibility)
+  attr_reader encoded: String
 
   # ```ruby
   # ulid = ULID.generate
   # #=> ULID(2021-04-27 17:27:22.826 UTC: 01F4A5Y1YAQCYAYCTC7GRMJ9AA)
   # ulid.encode #=> "01F4A5Y1YAQCYAYCTC7GRMJ9AA"
-  # ulid.encode.frozen? #=> true
-  # ulid.encode.equal?(ulid.to_s) #=> true
   # ```
   def encode: -> String
   alias to_s encode
@@ -533,11 +535,12 @@ class ULID < Object
          | (untyped other) -> false
 
   # ```ruby
-  # ulid = ULID.generate
-  # #=> ULID(2021-04-27 17:27:22.826 UTC: 01F4A5Y1YAQCYAYCTC7GRMJ9AA)
-  # ulid.to_time #=> 2021-04-27 17:27:22.826 UTC
+  # ULID.parse('01F4A5Y1YAQCYAYCTC7GRMJ9AA').to_time
+  # #=> 2021-04-27 17:27:22.826 UTC
+  # ULID.parse('01F4A5Y1YAQCYAYCTC7GRMJ9AA').to_time(in: '+09:00')
+  # #=> 2021-04-28 02:27:22.826 +0900
   # ```
-  def to_time: -> Time
+  def to_time: (?in: time_in) -> Time
 
   # ```ruby
   # ulid = ULID.generate
@@ -598,7 +601,6 @@ class ULID < Object
   #
   # See also [ULID#succ](https://kachick.github.io/ruby-ulid/ULID.html#succ-instance_method)
   def pred: -> ULID?
-  def freeze: -> self
 
   def marshal_dump: -> Integer
 
@@ -607,16 +609,7 @@ class ULID < Object
   # Returns `self`
   def to_ulid: -> self
 
-  # Returns `self`. Not a new instance.
-  def dup: -> self
-
-  # Same API as [Object#clone](https://github.com/ruby/rbs/blob/4fb4c33b2325d1a73d79ff7aaeb49f21cec1e0e5/core/object.rbs#L79)
-  # But actually returns `self`. Not a new instance.
-  def clone: (?freeze: bool) -> self
-
   private
 
   def initialize: (milliseconds: milliseconds, entropy: Integer, integer: Integer, encoded: String) -> void
-
-  def cache_all_instance_variables: -> void
 end

--- a/test/core/test_ractor_shareable.rb
+++ b/test/core/test_ractor_shareable.rb
@@ -22,12 +22,8 @@ class TestRactorShareable < Test::Unit::TestCase
     assert_false(Ractor.shareable?(ULID_INSTANCE))
     assert_false(Ractor.shareable?(MONOTONIC_GENERATOR))
 
-    if RUBY_VERSION >= '3.1'
-      assert_true(Ractor.shareable?(ULID_FROZEN_INSTANCE))
-      assert_equal('01F4GNAV5ZR6FJQ5SFQC7WDSY3', Ractor.new { ULID_FROZEN_INSTANCE.to_s }.take)
-    else
-      assert_false(Ractor.shareable?(ULID_FROZEN_INSTANCE))
-    end
+    assert_true(Ractor.shareable?(ULID_FROZEN_INSTANCE))
+    assert_equal('01F4GNAV5ZR6FJQ5SFQC7WDSY3', Ractor.new { ULID_FROZEN_INSTANCE.to_s }.take)
 
     assert_instance_of(ULID, Ractor.new { ULID_CLASS.generate }.take)
 

--- a/test/core/test_ractor_shareable.rb
+++ b/test/core/test_ractor_shareable.rb
@@ -60,7 +60,6 @@ class TestRactorShareable < Test::Unit::TestCase
     assert_true(Ractor.shareable?(ulid))
   end
 
-
   const_name_to_value = ULID.constants.to_h { |const_name| [const_name, ULID.const_get(const_name)] }
   raise unless const_name_to_value.size >= 10
   const_name_to_value.each_pair do |name, value|

--- a/test/core/test_ractor_shareable.rb
+++ b/test/core/test_ractor_shareable.rb
@@ -16,7 +16,7 @@ class TestRactorShareable < Test::Unit::TestCase
     Warning[:experimental] = false
   end
 
-  def test_shareable
+  def test_signature
     assert_true(Ractor.shareable?(ULID_CLASS))
     assert_false(ULID_CLASS.frozen?)
     assert_false(Ractor.shareable?(ULID_INSTANCE))
@@ -57,6 +57,13 @@ class TestRactorShareable < Test::Unit::TestCase
       end.take
     )
   end
+
+  def test_instances_are_can_be_shareable
+    ulid = ULID.generate
+    Ractor.make_shareable(ulid)
+    assert_true(Ractor.shareable?(ulid))
+  end
+
 
   const_name_to_value = ULID.constants.to_h { |const_name| [const_name, ULID.const_get(const_name)] }
   raise unless const_name_to_value.size >= 10

--- a/test/core/test_ulid_class.rb
+++ b/test/core/test_ulid_class.rb
@@ -255,10 +255,7 @@ class TestULIDClass < Test::Unit::TestCase
     assert(normalized.frozen?)
     assert_not_same(normalized, ULID.normalize(normalized))
 
-    # This behavior is controversial, should be return non frozen string?
-    assert do
-      ULID.normalize(normalized).frozen?
-    end
+    assert_false(ULID.normalize(normalized).frozen?)
 
     # Ensure the string is not modified in parser
     assert_false(downcased.frozen?)
@@ -431,6 +428,10 @@ class TestULIDClass < Test::Unit::TestCase
     assert_false(range.cover?(ULID.generate(moment: time_has_more_value_than_milliseconds2)))
     assert_true(range.cover?(range.begin))
     assert_true(range.cover?(range.end))
+    if RUBY_VERSION >= '3.0'
+      # Just a note
+      assert_true(range.frozen?)
+    end
     assert_false(range.begin.frozen?)
     assert_false(range.end.frozen?)
     assert_true(from_time.begin.frozen?)

--- a/test/core/test_ulid_instance.rb
+++ b/test/core/test_ulid_instance.rb
@@ -23,12 +23,9 @@ class TestULIDInstance < Test::Unit::TestCase
         :<=>,
         :==,
         :===,
-        :clone,
-        :dup,
         :encode,
         :entropy,
         :eql?,
-        :freeze,
         :hash,
         :inspect,
         :marshal_dump,
@@ -56,8 +53,9 @@ class TestULIDInstance < Test::Unit::TestCase
     ulid = ULID.parse('01ARZ3NDEKTSV4RRFFQ69G5FAV')
     assert_equal('01ARZ3NDEK', ulid.timestamp)
     assert_instance_of(String, ulid.timestamp)
-    assert_same(ulid.timestamp, ulid.timestamp)
-    assert_true(ulid.timestamp.frozen?)
+    assert_not_same(ulid.timestamp, ulid.timestamp)
+    assert_equal(ulid.timestamp, ulid.timestamp)
+    assert_false(ulid.timestamp.frozen?)
     assert_equal(Encoding::US_ASCII, ulid.timestamp.encoding)
   end
 
@@ -65,8 +63,9 @@ class TestULIDInstance < Test::Unit::TestCase
     ulid = ULID.parse('01ARZ3NDEKTSV4RRFFQ69G5FAV')
     assert_equal('TSV4RRFFQ69G5FAV', ulid.randomness)
     assert_instance_of(String, ulid.randomness)
-    assert_same(ulid.randomness, ulid.randomness)
-    assert_true(ulid.randomness.frozen?)
+    assert_not_same(ulid.randomness, ulid.randomness)
+    assert_equal(ulid.randomness, ulid.randomness)
+    assert_false(ulid.randomness.frozen?)
     assert_equal(Encoding::US_ASCII, ulid.randomness.encoding)
   end
 
@@ -182,24 +181,28 @@ class TestULIDInstance < Test::Unit::TestCase
   def test_encode
     ulid = ULID.parse('01ARZ3NDEKTSV4RRFFQ69G5FAV')
     assert_equal('01ARZ3NDEKTSV4RRFFQ69G5FAV', ulid.encode)
-    assert_same(ulid.encode, ulid.encode)
-    assert_true(ulid.encode.frozen?)
-    assert_same(ulid.to_s, ulid.encode)
+    assert_not_same(ulid.encode, ulid.encode)
+    assert_equal(ulid.encode, ulid.encode)
+    assert_false(ulid.encode.frozen?)
+    assert_not_same(ulid.to_s, ulid.encode)
   end
 
   def test_to_s
     ulid = ULID.parse('01ARZ3NDEKTSV4RRFFQ69G5FAV')
     assert_equal('01ARZ3NDEKTSV4RRFFQ69G5FAV', ulid.to_s)
-    assert_same(ulid.to_s, ulid.to_s)
-    assert_true(ulid.to_s.frozen?)
-    assert_same(ulid.encode, ulid.to_s)
+    assert_not_same(ulid.to_s, ulid.to_s)
+    assert_equal(ulid.to_s, ulid.to_s)
+    assert_false(ulid.to_s.frozen?)
+    assert_not_same(ulid.encode, ulid.to_s)
+    assert_equal(ulid.encode, ulid.to_s)
   end
 
   def test_inspect
     ulid = ULID.parse('01ARZ3NDEKTSV4RRFFQ69G5FAV')
     assert_equal('ULID(2016-07-30 23:54:10.259 UTC: 01ARZ3NDEKTSV4RRFFQ69G5FAV)', ulid.inspect)
-    assert_same(ulid.inspect, ulid.inspect)
-    assert_true(ulid.inspect.frozen?)
+    assert_not_same(ulid.inspect, ulid.inspect)
+    assert_equal(ulid.inspect, ulid.inspect)
+    assert_false(ulid.inspect.frozen?)
     assert_not_equal(ulid.to_s, ulid.inspect)
     assert_equal(Encoding::US_ASCII, ulid.inspect.encoding)
 
@@ -266,20 +269,24 @@ class TestULIDInstance < Test::Unit::TestCase
 
   def test_dup
     ulid = ULID.sample
-    assert_same(ulid, ulid.dup)
+    assert_equal(ulid, ulid.dup)
+    assert_not_same(ulid, ulid.dup)
+    assert_false(ulid.frozen?)
+    assert_false(ulid.dup.frozen?)
   end
 
   def test_clone
     ulid = ULID.sample
-    assert_same(ulid, ulid.clone)
-    assert_same(ulid, ulid.clone(freeze: true))
-    assert_same(ulid, ulid.clone(freeze: false))
+    assert_equal(ulid, ulid.clone)
+    assert_not_same(ulid, ulid.clone)
+    assert_false(ulid.frozen?)
+    assert_false(ulid.clone.frozen?)
   end
 
   def test_instance_variable_set
     ulid = ULID.sample
     int = ulid.to_i
-    str = ulid.to_s
+    str = ulid.instance_variable_get(:@encoded)
 
     assert_raises(NoMethodError) do
       ulid.instance_variable_set(:@integer, int + 42)
@@ -288,9 +295,8 @@ class TestULIDInstance < Test::Unit::TestCase
     assert_equal(int, ulid.instance_variable_get(:@integer))
 
     assert_raises(NoMethodError) do
-      ulid.instance_variable_set(:@encoded, str.downcase)
+      ulid.instance_variable_set(:@encoded, str.dup.downcase)
     end
-    assert_same(str, ulid.to_s)
     assert_same(str, ulid.instance_variable_get(:@encoded))
   end
 
@@ -304,12 +310,9 @@ class TestULIDInstance < Test::Unit::TestCase
     time = ulid.to_time
     assert_equal(Time.at(0, 1469922850259, :millisecond).utc, time)
     assert_true(time.utc?)
-    assert_same(ulid.to_time, time)
-    assert_true(time.frozen?)
-
-    assert_raises(FrozenError) do
-      time.localtime(time.utc_offset.succ)
-    end
+    assert_not_same(ulid.to_time, time)
+    assert_equal(ulid.to_time, time)
+    assert_false(time.frozen?)
   end
 
   def test_octets

--- a/test/core/test_ulid_instance.rb
+++ b/test/core/test_ulid_instance.rb
@@ -202,7 +202,11 @@ class TestULIDInstance < Test::Unit::TestCase
     assert_equal('ULID(2016-07-30 23:54:10.259 UTC: 01ARZ3NDEKTSV4RRFFQ69G5FAV)', ulid.inspect)
     assert_not_same(ulid.inspect, ulid.inspect)
     assert_equal(ulid.inspect, ulid.inspect)
-    assert_false(ulid.inspect.frozen?)
+    if RUBY_VERSION >= '3.0'
+      # Because of https://bugs.ruby-lang.org/issues/17104
+      # Do not care 2.7.x adjustment in this library.
+      assert_false(ulid.inspect.frozen?)
+    end
     assert_not_equal(ulid.to_s, ulid.inspect)
     assert_equal(Encoding::US_ASCII, ulid.inspect.encoding)
 

--- a/test/core/test_ulid_usecase.rb
+++ b/test/core/test_ulid_usecase.rb
@@ -142,7 +142,7 @@ class TestULIDUseCase < Test::Unit::TestCase
     frozen = ULID.sample.freeze
     dumped = Marshal.dump(frozen)
     unmarshaled = Marshal.load(dumped)
-    assert(!unmarshaled.frozen?)
-    assert(unmarshaled.to_s.frozen?)
+    assert_false(unmarshaled.frozen?)
+    assert_false(unmarshaled.to_s.frozen?)
   end
 end


### PR DESCRIPTION
Lazy caching brings many complexity of the implementation.
This PR removes them.

It needs some signature changes for the returning values. However it will be same signature of built-in classes. I hope the impact is not big.