### PR TITLE
Integrate dprint-plugin-exec to use rubocop as a simple formatter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,4 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dprint/check@v2.1
+      - name: Install dprint
+        run: |
+          curl -fsSL https://dprint.dev/install.sh | sh -s 0.34.1 > /dev/null 2>&1
+          echo "/home/runner/.dprint/bin" >> $GITHUB_PATH
+      - name: Check formatting
+        run: ~/.dprint/bin/dprint --config dprint-ci.json check

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,7 +7,6 @@
     "soutaro.steep-vscode",
     "soutaro.rbs-syntax",
     "dprint.dprint",
-    "pucelle.run-on-save",
     "jnoortheen.nix-ide"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,16 +1,6 @@
 {
   "editor.defaultFormatter": "dprint.dprint",
   "editor.formatOnSave": true,
-  "runOnSave.statusMessageTimeout": 3000,
-  "runOnSave.commands": [
-    {
-      "match": "(.*\\.rb|Rakefile|Gemfile|.*\\.gemspec)$",
-      "command": "bundle exec rubocop --autocorrect ${file}",
-      "runIn": "backend",
-      "runningStatusMessage": "Formatting with rubocop ${fileBasename}",
-      "finishStatusMessage": "${fileBasename} formatted"
-    }
-  ],
   "cSpell.words": [
     "kwargs",
     "Undocumentable",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,17 +19,19 @@ $ dprint --version
 $ bundle install || bundle update
 ```
 
-Author is using vscode for development.
+## Dprint
 
-### Note - rubocop in vscode
+Use dprint as below
 
-For your information, the rubocop vscode integration shows wrong errors for Rakefile and ruby-ulid.gemspec as below
-
-```text
-The name of this source file (`Rakefile'`) should use snake_case.
+```console
+$ dprint --config dprint-ci.json check
+$ dprint --config dprint-ci.json fmt
 ```
 
-`bundle exec rubocop` does not show this messsage. It looks fixed in https://github.com/rubyide/vscode-ruby/pull/647. However it is not released yet at 2022-05-26. (https://github.com/rubyide/vscode-ruby/commit/dc81c809c82003d26af9c4dc7c89fa8f8a26cbf5 "rebornix.ruby" maintainance is inactive now)
+Providing 2 config files. For the purpose below
+
+* [dprint-ci.json](dprint-ci.json) - Except ruby for faster run
+* [dprint.json](dprint.json) - Includes rubocop integration. Just using in vscode
 
 ## Touch the development version with REPL
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,8 +30,8 @@ $ dprint --config dprint-ci.json fmt
 
 Providing 2 config files. For the purpose below
 
-* [dprint-ci.json](dprint-ci.json) - Except ruby for faster run
-* [dprint.json](dprint.json) - Includes rubocop integration. Just using in vscode
+- [dprint-ci.json](dprint-ci.json) - Except ruby for faster run
+- [dprint.json](dprint.json) - Includes rubocop integration. Just using in vscode
 
 ## Touch the development version with REPL
 

--- a/dprint-ci.json
+++ b/dprint-ci.json
@@ -1,0 +1,26 @@
+{
+  "json": {
+  },
+  "markdown": {
+  },
+  "exec": {
+  },
+  "prettier": {
+    "printWidth": 120,
+    "singleQuote": true
+  },
+  "includes": ["**/*.{json,md,yml,html,css}"],
+  "excludes": [
+    ".git",
+    "**/*lock.json",
+    "docs",
+    "doc",
+    "steep_expectations.yml"
+  ],
+  "plugins": [
+    "https://plugins.dprint.dev/json-0.17.0.wasm",
+    "https://plugins.dprint.dev/markdown-0.15.2.wasm",
+    "https://plugins.dprint.dev/exec-0.3.5.json@d687dda57be0fe9a0088ccdaefa5147649ff24127d8b3ea227536c68ee7abeab",
+    "https://plugins.dprint.dev/prettier-0.19.0.json@f2ca8ddf0a5d7eca344681f54a9280250727324d09475f201fa2584faa2300c5"
+  ]
+}

--- a/dprint.json
+++ b/dprint.json
@@ -18,6 +18,7 @@
   "plugins": [
     "https://plugins.dprint.dev/json-0.17.0.wasm",
     "https://plugins.dprint.dev/markdown-0.15.2.wasm",
+    "https://plugins.dprint.dev/exec-0.3.5.json@d687dda57be0fe9a0088ccdaefa5147649ff24127d8b3ea227536c68ee7abeab",
     "https://plugins.dprint.dev/prettier-0.19.0.json@f2ca8ddf0a5d7eca344681f54a9280250727324d09475f201fa2584faa2300c5"
   ]
 }

--- a/dprint.json
+++ b/dprint.json
@@ -1,16 +1,9 @@
 {
-  "json": {
-  },
-  "markdown": {
-  },
+  "extends": "dprint-ci.json",
   "exec": {
     "associations": ["**/*.{rb,gemspec,rake}", "Rakefile", "Gemfile", "Steepfile"],
     "rubocop": "bundle exec rubocop --autocorrect --stdin {{file_path}} --stderr",
     "rubocop.associations": "**/**"
-  },
-  "prettier": {
-    "printWidth": 120,
-    "singleQuote": true
   },
   "includes": ["**/*.{json,md,yml,html,css,rb,gemspec,rake}", "{Rakefile,Gemfile,Steepfile}"],
   "excludes": [
@@ -19,11 +12,5 @@
     "docs",
     "doc",
     "steep_expectations.yml"
-  ],
-  "plugins": [
-    "https://plugins.dprint.dev/json-0.17.0.wasm",
-    "https://plugins.dprint.dev/markdown-0.15.2.wasm",
-    "https://plugins.dprint.dev/exec-0.3.5.json@d687dda57be0fe9a0088ccdaefa5147649ff24127d8b3ea227536c68ee7abeab",
-    "https://plugins.dprint.dev/prettier-0.19.0.json@f2ca8ddf0a5d7eca344681f54a9280250727324d09475f201fa2584faa2300c5"
   ]
 }

--- a/dprint.json
+++ b/dprint.json
@@ -3,11 +3,16 @@
   },
   "markdown": {
   },
+  "exec": {
+    "associations": ["**/*.{rb,gemspec,rake}", "Rakefile", "Gemfile", "Steepfile"],
+    "rubocop": "bundle exec rubocop --autocorrect --stdin {{file_path}} --stderr",
+    "rubocop.associations": "**/**"
+  },
   "prettier": {
     "printWidth": 120,
     "singleQuote": true
   },
-  "includes": ["**/*.{json,md,yml,html,css}"],
+  "includes": ["**/*.{json,md,yml,html,css,rb,gemspec,rake}", "{Rakefile,Gemfile,Steepfile}"],
   "excludes": [
     ".git",
     "**/*lock.json",


### PR DESCRIPTION
Update https://github.com/kachick/ruby-ulid/pull/314 with https://github.com/dprint/dprint-plugin-exec

Much more simpler 🎉 