### PR TITLE
Revert to add alias ULID#bytes to avoid naming conflict with Random::Formatter#random_bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ ulid.to_s #=> "01F4A5Y1YAQCYAYCTC7GRMJ9AA"
 ulid.timestamp #=> "01F4A5Y1YA"
 ulid.randomness #=> "QCYAYCTC7GRMJ9AA"
 ulid.to_i #=> 1957909092946624190749577070267409738
-ulid.bytes #=> [1, 121, 20, 95, 7, 202, 187, 60, 175, 51, 76, 60, 49, 73, 37, 74]
+ulid.octets #=> [1, 121, 20, 95, 7, 202, 187, 60, 175, 51, 76, 60, 49, 73, 37, 74]
 ```
 
 `ULID.generate` can take fixed `Time` instance. `ULID.at` is the shorthand.

--- a/lib/ulid.rb
+++ b/lib/ulid.rb
@@ -438,7 +438,6 @@ class ULID
     digits = @integer.digits(256)
     digits.fill(0, digits.size, OCTETS_LENGTH - digits.size).reverse
   end
-  alias_method(:bytes, :octets)
 
   # @return [String]
   def timestamp
@@ -506,7 +505,7 @@ class ULID
   #
   # @return [String]
   def to_uuidish
-    UUID::Fields.raw_from_bytes(bytes).to_s.freeze
+    UUID::Fields.raw_from_octets(octets).to_s.freeze
   end
 
   # Generate a UUIDv4-like string that sets the version and variants field.
@@ -518,9 +517,9 @@ class ULID
   # @param [bool] force
   # @return [String]
   def to_uuidv4(force: false)
-    v4 = UUID::Fields.forced_v4_from_bytes(bytes)
+    v4 = UUID::Fields.forced_v4_from_octets(octets)
     unless force
-      uuidish = UUID::Fields.raw_from_bytes(bytes)
+      uuidish = UUID::Fields.raw_from_octets(octets)
       raise(IrreversibleUUIDError) unless uuidish == v4
     end
 

--- a/lib/ulid/uuid.rb
+++ b/lib/ulid/uuid.rb
@@ -42,15 +42,15 @@ class ULID
     # @todo Replace to Data class after dropped Ruby 3.1
     # @note Using `Fields = Struct.new` syntax made https://github.com/kachick/ruby-ulid/issues/233 again. So use class syntax instead
     class Fields < Struct.new(:time_low, :time_mid, :time_hi_and_version, :clock_seq_hi_and_res, :clk_seq_low, :node, keyword_init: true)
-      def self.raw_from_bytes(bytes)
-        case bytes.pack('C*').unpack('NnnnnN')
+      def self.raw_from_octets(octets)
+        case octets.pack('C*').unpack('NnnnnN')
         in [Integer => time_low, Integer => time_mid, Integer => time_hi_and_version, Integer => clock_seq_hi_and_res, Integer => clk_seq_low, Integer => node]
           new(time_low:, time_mid:, time_hi_and_version:, clock_seq_hi_and_res:, clk_seq_low:, node:).freeze
         end
       end
 
-      def self.forced_v4_from_bytes(bytes)
-        case bytes.pack('C*').unpack('NnnnnN')
+      def self.forced_v4_from_octets(octets)
+        case octets.pack('C*').unpack('NnnnnN')
         in [Integer => time_low, Integer => time_mid, Integer => time_hi_and_version, Integer => clock_seq_hi_and_res, Integer => clk_seq_low, Integer => node]
           new(
             time_low:,

--- a/scripts/generate_many_examples.rb
+++ b/scripts/generate_many_examples.rb
@@ -43,7 +43,7 @@ examples = [ancient, recently, distant_future, limit_of_the_ulid].flat_map do |p
       integer: ulid.to_i,
       timestamp: ulid.timestamp,
       randomness: ulid.randomness,
-      octets: ulid.bytes,
+      octets: ulid.octets,
       inspect: ulid.inspect,
       uuidv4: ulid.to_uuidv4
     )

--- a/sig/ulid.rbs
+++ b/sig/ulid.rbs
@@ -48,8 +48,8 @@ class ULID < Object
       attr_accessor clock_seq_hi_and_res: Integer
       attr_accessor clk_seq_low: Integer
       attr_accessor node: Integer
-      def self.raw_from_bytes: (octets) -> Fields
-      def self.forced_v4_from_bytes: (octets) -> Fields
+      def self.raw_from_octets: (octets) -> Fields
+      def self.forced_v4_from_octets: (octets) -> Fields
 
       def values: -> Array[Integer]
 
@@ -580,7 +580,6 @@ class ULID < Object
   def randomness: -> String
 
   def octets: -> octets
-  alias bytes octets
 
   # Returns next(successor) ULID.\
   # Especially `ULID#succ` makes it possible `Range[ULID]#each`.

--- a/test/core/test_boundary_ulid.rb
+++ b/test/core/test_boundary_ulid.rb
@@ -31,12 +31,4 @@ class TestBoundaryULID < Test::Unit::TestCase
     assert_equal(ULID.parse('01BX5ZZKBJZZZZZZZZZZZZZZZZ'), @min_entropy.pred)
     assert_same(@min, ULID.parse('00000000000000000000000001').pred)
   end
-
-  def test_bytes
-    assert_equal([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], @min.bytes)
-    assert_equal([255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255], @max.bytes)
-
-    # Not 0, but too low as 0 parts in the prefix
-    assert_equal([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 121, 50], ULID.from_integer(424242).bytes)
-  end
 end

--- a/test/core/test_ulid_instance.rb
+++ b/test/core/test_ulid_instance.rb
@@ -18,7 +18,6 @@ class TestULIDInstance < Test::Unit::TestCase
     milliseconds
     next
     octets
-    bytes
     pred
     randomness
     succ
@@ -108,7 +107,7 @@ class TestULIDInstance < Test::Unit::TestCase
     assert_false(ulid === ulid.randomness)
     assert_false(ulid === ulid.milliseconds)
     assert_false(ulid === ulid.entropy)
-    assert_false(ulid === ulid.bytes)
+    assert_false(ulid === ulid.octets)
     assert_false(ulid === ulid.pred.to_s)
     assert_false(ulid === ulid.next.to_s)
     assert_false(ulid === '')
@@ -313,13 +312,6 @@ class TestULIDInstance < Test::Unit::TestCase
     assert_not_same(ulid.to_time, time)
     assert_equal(ulid.to_time, time)
     assert_false(time.frozen?)
-  end
-
-  def test_bytes
-    ulid = ULID.parse('01ARZ3NDEKTSV4RRFFQ69G5FAV')
-    assert_equal([1, 86, 62, 58, 181, 211, 214, 118, 76, 97, 239, 185, 147, 2, 189, 91], ulid.bytes)
-    assert_not_same(ulid.bytes, ulid.bytes)
-    assert_false(ulid.bytes.frozen?)
   end
 
   def test_octets

--- a/test/core/test_ulid_usecase.rb
+++ b/test/core/test_ulid_usecase.rb
@@ -78,7 +78,7 @@ class TestULIDUseCase < Test::Unit::TestCase
     assert_equal(ulid.timestamp, unmarshaled.timestamp)
     assert_equal(ulid.randomness, unmarshaled.randomness)
     assert_equal(ulid.milliseconds, unmarshaled.milliseconds)
-    assert_equal(ulid.bytes, unmarshaled.bytes)
+    assert_equal(ulid.octets, unmarshaled.octets)
 
     # Do not ensure frozen instance behaviors, this tests just check current behavior
     frozen = ULID.sample.freeze

--- a/test/many_data/test_fixed_many_data.rb
+++ b/test/many_data/test_fixed_many_data.rb
@@ -21,7 +21,7 @@ class TestFixedManyData < Test::Unit::TestCase
     assert_equal(example.randomness, ulid.randomness)
     assert_equal(example.uuidv4, ulid.to_uuidv4(force: true))
     assert_equal(example.to_time, ulid.to_time)
-    assert_equal(example.octets, ulid.bytes)
+    assert_equal(example.octets, ulid.octets)
 
     assert do
       ULID.normalized?(example.string)

--- a/test/many_data/test_randomized_many_data.rb
+++ b/test/many_data/test_randomized_many_data.rb
@@ -45,13 +45,13 @@ class TestManyData < Test::Unit::TestCase
     end
   end
 
-  def test_bytes
+  def test_octets
     ULID.sample(10000).each do |ulid|
-      assert_instance_of(Array, ulid.bytes)
-      assert(ulid.bytes.all?(Integer))
-      assert_equal(ULID.const_get(:OCTETS_LENGTH), ulid.bytes.size)
-      assert_not_same(ulid.bytes, ulid.bytes)
-      assert_false(ulid.bytes.frozen?)
+      assert_instance_of(Array, ulid.octets)
+      assert(ulid.octets.all?(Integer))
+      assert_equal(ULID.const_get(:OCTETS_LENGTH), ulid.octets.size)
+      assert_not_same(ulid.octets, ulid.octets)
+      assert_false(ulid.octets.frozen?)
     end
   end
 end


### PR DESCRIPTION
Random::Formatter#random_bytes returns ASCII-8BIT strings

ref: #342