### PR TITLE
Bump steep to 1.4 and RBS to 3 again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,9 +16,6 @@ updates:
           - '1.31.2'
           # https://github.com/rubocop/rubocop/issues/11549
           - '1.45.0'
-      - dependency-name: 'rbs'
-        # https://github.com/soutaro/steep/issues/725#issuecomment-1455649161
-        update-types: ['version-update:semver-major']
   - package-ecosystem: 'bundler'
     directory: '/benchmark/compare_with_othergems/kachick'
     schedule:

--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,8 @@ end
 
 group(:development) do
   gem('debug', '~> 1.7.2', require: false)
-  gem('rbs', '~> 2.8.4', require: false)
-  gem('steep', '~> 1.3.2', require: false)
+  gem('rbs', '~> 3.0.4', require: false)
+  gem('steep', '~> 1.4.0', require: false)
   gem('benchmark-ips', '~> 2.12.0', require: false)
   gem('stackprof')
   gem('yard', '~> 0.9.34', require: false)


### PR DESCRIPTION
steep has been released non major version of 1.4 https://github.com/soutaro/steep/releases/tag/v1.4.0

#347
#331
https://github.com/kachick/ruby-ulid/pull/367#issuecomment-1519872178