### PR TITLE
Enable macOS CI again with faster runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,9 @@ jobs:
         os: ['ubuntu-latest']
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for 'n.0'
         ruby: ['head', '3.2', '3.1']
-        # # Disabled macos runner. This gem should work because of it is written in pure ruby :). And the runner is too slow and often be stacked.
-        # include:
-        #   - os: 'macos-latest'
-        #     ruby: '3.2'
+        include:
+          - os: 'macos-latest-xl'
+            ruby: '3.2'
         # # Windows CI takes longtime. It has been succeeded in #223, it is enough for now.
         # - os: 'windows-latest'
         #   ruby: '3.2'


### PR DESCRIPTION
Try for https://github.com/kachick/ruby-ulid/pull/223#issuecomment-1190947115

https://github.blog/changelog/2023-04-24-github-actions-faster-macos-runners-are-now-available-in-open-public-beta/