### PR TITLE
Install libyaml in Nix env

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,11 @@
               bashInteractive
 
               ruby_3_2
+              # Required to build psych via irb dependency
+              # https://github.com/kachick/irb-power_assert/issues/116
+              # https://github.com/ruby/irb/pull/648
+              libyaml
+
               dprint
               tree
               nil
@@ -48,6 +53,7 @@
             '';
             runtimeDependencies = [
               pkgs.ruby_3_2
+              pkgs.libyaml
             ];
           };
 


### PR DESCRIPTION
Since irb 1.8.0, added rdoc requirements made psych error in `bundle install`

https://github.com/ruby/irb/pull/648
https://github.com/kachick/irb-power_assert/pull/117
https://github.com/kachick/rspec-matchers-power_assert_matchers/pull/123