### PR TITLE
Revert to install libffi and pkg-config in nix shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,11 +26,6 @@
               # https://github.com/kachick/irb-power_assert/issues/116
               # https://github.com/ruby/irb/pull/648
               libyaml
-              # Required to build ffi via steep dependency
-              # https://github.com/kachick/ruby-ulid/issues/423
-              libffi
-              # Needed for libffi in darwin
-              pkg-config
 
               dprint
               tree


### PR DESCRIPTION
Because of ffi gem fixed the problems since 1.16.1

https://github.com/ffi/ffi/commit/ce6f419d17d9bc8a8174e72e425d42e90aad34a0
https://github.com/ffi/ffi/releases/tag/v1.16.1

ref: https://github.com/kachick/ruby-ulid/issues/423, https://github.com/kachick/ruby-ulid/pull/424, https://github.com/ffi/ffi/issues/1049