### PR TITLE
Update test with new error message format

### DIFF
--- a/test/core/test_ulid_class.rb
+++ b/test/core/test_ulid_class.rb
@@ -221,7 +221,7 @@ class TestULIDClass < Test::Unit::TestCase
     err = assert_raises(NoMethodError) do
       ULID.new(milliseconds: 0, entropy: 42)
     end
-    assert_match(/private method `new' called/, err.message)
+    assert_match(/private method (`|')new' called/, err.message)
   end
 
   def test_normalize

--- a/test/core/test_ulid_class.rb
+++ b/test/core/test_ulid_class.rb
@@ -221,6 +221,7 @@ class TestULIDClass < Test::Unit::TestCase
     err = assert_raises(NoMethodError) do
       ULID.new(milliseconds: 0, entropy: 42)
     end
+    # NoMethodError#private_call? will not fit. Checking the error message is not a good test, but required at here
     assert_match(/private method (`|')new' called/, err.message)
   end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,8 @@
 # coding: us-ascii
 # frozen_string_literal: true
 
+# TODO: Remove this line after #495
+
 # How to use: https://github.com/jeremyevans/ruby-warning
 require('warning')
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,8 +1,6 @@
 # coding: us-ascii
 # frozen_string_literal: true
 
-# TODO: Remove this line after #495
-
 # How to use: https://github.com/jeremyevans/ruby-warning
 require('warning')
 


### PR DESCRIPTION
Noticed by https://github.com/kachick/ruby-ulid/pull/494#issuecomment-1951623650

https://github.com/kachick/ruby-ulid/pull/494#issuecomment-1951623650

ruby-head changed the message format

https://github.com/ruby/ruby/pull/9605
https://github.com/ruby/ruby/commit/9ec9910081b5d91becf9d9d8df7ea65c2ccc3a71