### PR TITLE
Implement `ULID#{+,-}` to follow Range#step changes in ruby-3.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ ULID.parse('00000000000000000000000000').pred #=> nil
 `ULID#+` is also provided to realize `Range#step` since [ruby-3.4.0 spec changes](https://bugs.ruby-lang.org/issues/18368).
 
 ```ruby
+# This code works only in ruby-3.4.0dev or later
 (ULID.min...).step(42).take(3)
 # =>
 [ULID(1970-01-01 00:00:00.000 UTC: 00000000000000000000000000),

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ ULID.min(time) #=> ULID(2000-01-01 00:00:00.123 UTC: 00VHNCZB3V0000000000000000)
 ULID.max(time) #=> ULID(2000-01-01 00:00:00.123 UTC: 00VHNCZB3VZZZZZZZZZZZZZZZZ)
 ```
 
-#### As element in Enumerable
+#### As an element in Enumerable and Range
 
 `ULID#next` and `ULID#succ` returns next(successor) ULID.\
 Especially `ULID#succ` makes it possible `Range[ULID]#each`.
@@ -299,6 +299,16 @@ ULID.parse('7ZZZZZZZZZZZZZZZZZZZZZZZZZ').next #=> nil
 ULID.parse('01BX5ZZKBK0000000000000001').pred.to_s #=> "01BX5ZZKBK0000000000000000"
 ULID.parse('01BX5ZZKBK0000000000000000').pred.to_s #=> "01BX5ZZKBJZZZZZZZZZZZZZZZZ"
 ULID.parse('00000000000000000000000000').pred #=> nil
+```
+
+`ULID#+` is also provided to realize `Range#step` since [ruby-3.4.0 spec changes](https://bugs.ruby-lang.org/issues/18368).
+
+```ruby
+(ULID.min...).step(42).take(3)
+# =>
+[ULID(1970-01-01 00:00:00.000 UTC: 00000000000000000000000000),
+ ULID(1970-01-01 00:00:00.000 UTC: 0000000000000000000000001A),
+ ULID(1970-01-01 00:00:00.000 UTC: 0000000000000000000000002M)]
 ```
 
 #### Test helpers

--- a/lib/ulid.rb
+++ b/lib/ulid.rb
@@ -450,32 +450,29 @@ class ULID
   end
 
   # @return [ULID, nil] when called on ULID as `7ZZZZZZZZZZZZZZZZZZZZZZZZZ`, returns `nil` instead of ULID
-  def succ
-    succ_int = @integer.succ
-    if succ_int >= MAX_INTEGER
-      if succ_int == MAX_INTEGER
-        MAX
-      else
-        nil
-      end
+  def +(other)
+    new_int = @integer + other
+    case new_int
+    when MAX_INTEGER
+      MAX
+    when 0
+      MIN
+    when ->v { v > MAX_INTEGER || v < 0 }
+      nil
     else
-      ULID.from_integer(succ_int)
+      ULID.from_integer(new_int)
     end
+  end
+
+  # @return [ULID, nil] when called on ULID as `7ZZZZZZZZZZZZZZZZZZZZZZZZZ`, returns `nil` instead of ULID
+  def succ
+    self + 1
   end
   alias_method(:next, :succ)
 
   # @return [ULID, nil] when called on ULID as `00000000000000000000000000`, returns `nil` instead of ULID
   def pred
-    pred_int = @integer.pred
-    if pred_int <= 0
-      if pred_int == 0
-        MIN
-      else
-        nil
-      end
-    else
-      ULID.from_integer(pred_int)
-    end
+    self + -1
   end
 
   # @return [Integer]

--- a/lib/ulid.rb
+++ b/lib/ulid.rb
@@ -449,19 +449,32 @@ class ULID
     @encoded.slice(TIMESTAMP_ENCODED_LENGTH, RANDOMNESS_ENCODED_LENGTH) || raise(UnexpectedError)
   end
 
-  # @return [ULID, nil] when called on ULID as `7ZZZZZZZZZZZZZZZZZZZZZZZZZ`, returns `nil` instead of ULID
+  # @param [Integer] other
+  # @return [ULID, nil] when returning URID might be greater than `7ZZZZZZZZZZZZZZZZZZZZZZZZZ`, returns `nil` instead of ULID
   def +(other)
+    raise(ArgumentError, 'ULID#+ takes only integers') unless Integer === other
+
     new_int = @integer + other
     case new_int
     when MAX_INTEGER
       MAX
     when 0
       MIN
-    when ->v { v > MAX_INTEGER || v < 0 }
-      nil
     else
-      ULID.from_integer(new_int)
+      if new_int > MAX_INTEGER || new_int < 0
+        nil
+      else
+        ULID.from_integer(new_int)
+      end
     end
+  end
+
+  # @param [Integer] other
+  # @return [ULID, nil] when returning URID might be less than `00000000000000000000000000`, returns `nil` instead of ULID
+  def -(other)
+    raise(ArgumentError, 'ULID#- takes only integers') unless Integer === other
+
+    self + -other
   end
 
   # @return [ULID, nil] when called on ULID as `7ZZZZZZZZZZZZZZZZZZZZZZZZZ`, returns `nil` instead of ULID
@@ -472,7 +485,7 @@ class ULID
 
   # @return [ULID, nil] when called on ULID as `00000000000000000000000000`, returns `nil` instead of ULID
   def pred
-    self + -1
+    self - 1
   end
 
   # @return [Integer]

--- a/sig/ulid.rbs
+++ b/sig/ulid.rbs
@@ -594,6 +594,18 @@ class ULID < Object
   # ```
   def octets: -> octets
 
+  # Returns incremented ULID.\
+  # Especially providing for Range#step since ruby-3.4.0 spec changes
+  #
+  # See also [ruby-lang#18368](https://bugs.ruby-lang.org/issues/18368)
+  # ```
+  def +: (Integer other) -> ULID?
+
+  # Returns decremented ULID.\
+  # Providing for realizing natural API convention with the `ULID#+`
+  # ```
+  def -: (Integer other) -> ULID?
+
   # Returns next(successor) ULID.\
   # Especially `ULID#succ` makes it possible `Range[ULID]#each`.
   #

--- a/test/core/test_boundary_ulid.rb
+++ b/test/core/test_boundary_ulid.rb
@@ -24,10 +24,12 @@ class TestBoundaryULID < Test::Unit::TestCase
     assert_nil(@max + 1)
     assert_equal(ULID.parse('01BX5ZZKBM0000000000000000'), @max_entropy + 1)
     assert_same(@max, ULID.parse('7ZZZZZZZZZZZZZZZZZZZZZZZZY') + 1)
+  end
 
-    assert_nil(@min + -1)
-    assert_equal(ULID.parse('01BX5ZZKBJZZZZZZZZZZZZZZZZ'), @min_entropy + -1)
-    assert_same(@min, ULID.parse('00000000000000000000000001') + -1)
+  def test_minus
+    assert_nil(@min - 1)
+    assert_equal(ULID.parse('01BX5ZZKBJZZZZZZZZZZZZZZZZ'), @min_entropy - 1)
+    assert_same(@min, ULID.parse('00000000000000000000000001') - 1)
   end
 
   def test_next

--- a/test/core/test_boundary_ulid.rb
+++ b/test/core/test_boundary_ulid.rb
@@ -20,6 +20,16 @@ class TestBoundaryULID < Test::Unit::TestCase
     assert_equal(0, @min.to_i)
   end
 
+  def test_plus
+    assert_nil(@max + 1)
+    assert_equal(ULID.parse('01BX5ZZKBM0000000000000000'), @max_entropy + 1)
+    assert_same(@max, ULID.parse('7ZZZZZZZZZZZZZZZZZZZZZZZZY') + 1)
+
+    assert_nil(@min + -1)
+    assert_equal(ULID.parse('01BX5ZZKBJZZZZZZZZZZZZZZZZ'), @min_entropy + -1)
+    assert_same(@min, ULID.parse('00000000000000000000000001') + -1)
+  end
+
   def test_next
     assert_nil(@max.next)
     assert_equal(ULID.parse('01BX5ZZKBM0000000000000000'), @max_entropy.next)

--- a/test/core/test_ulid_instance.rb
+++ b/test/core/test_ulid_instance.rb
@@ -321,6 +321,27 @@ class TestULIDInstance < Test::Unit::TestCase
     assert_false(ulid.octets.frozen?)
   end
 
+  def test_plus
+    ulid = ULID.parse('01ARZ3NDEKTSV4RRFFQ69G5FAV')
+    assert_equal((ulid + 42).to_i, ulid.to_i + 42)
+    assert_equal((ulid + -42).to_i, ulid.to_i - 42)
+    assert_instance_of(ULID, ulid + 42)
+    assert_not_same(ulid + 42, ulid + 42)
+    assert_raises(ArgumentError) do
+      ulid.__send__(:+)
+    end
+    assert_raises(ArgumentError) do
+      ulid.__send__(:+, 42, 6174)
+    end
+
+    [nil, '42', 42.1, BasicObject.new, Object.new, ULID.sample].each do |evil|
+      err = assert_raises(ArgumentError) do
+        ulid + evil
+      end
+      assert_equal('ULID#+ takes only integer', err.message)
+    end
+  end
+
   def test_succ
     ulid = ULID.parse('01ARZ3NDEKTSV4RRFFQ69G5FAV')
     assert_equal(ulid.succ.to_i, ulid.to_i + 1)

--- a/test/core/test_ulid_instance.rb
+++ b/test/core/test_ulid_instance.rb
@@ -326,6 +326,9 @@ class TestULIDInstance < Test::Unit::TestCase
     assert_equal(ulid.succ.to_i, ulid.to_i + 1)
     assert_instance_of(ULID, ulid.succ)
     assert_not_same(ulid.succ, ulid.succ)
+    assert_raises(ArgumentError) do
+      ulid.succ(1)
+    end
 
     first = ULID.parse('01BX5ZZKBKACTAV9WEVGEMMVRY')
     assert_equal(ULID.parse('01BX5ZZKBKACTAV9WEVGEMMVRZ'), first.succ)
@@ -338,6 +341,9 @@ class TestULIDInstance < Test::Unit::TestCase
     assert_equal(ulid.next.to_i, ulid.to_i + 1)
     assert_instance_of(ULID, ulid.next)
     assert_not_same(ulid.next, ulid.next)
+    assert_raises(ArgumentError) do
+      ulid.next(1)
+    end
 
     first = ULID.parse('01BX5ZZKBKACTAV9WEVGEMMVRY')
     assert_equal(ULID.parse('01BX5ZZKBKACTAV9WEVGEMMVRZ'), first.next)
@@ -350,6 +356,9 @@ class TestULIDInstance < Test::Unit::TestCase
     assert_equal(ulid.pred.to_i, ulid.to_i - 1)
     assert_instance_of(ULID, ulid.pred)
     assert_not_same(ulid.pred, ulid.pred)
+    assert_raises(ArgumentError) do
+      ulid.pred(1)
+    end
 
     first = ULID.parse('01BX5ZZKBKACTAV9WEVGEMMVR2')
     assert_equal(ULID.parse('01BX5ZZKBKACTAV9WEVGEMMVR1'), first.pred)

--- a/test/core/test_ulid_instance.rb
+++ b/test/core/test_ulid_instance.rb
@@ -321,6 +321,18 @@ class TestULIDInstance < Test::Unit::TestCase
     assert_false(ulid.octets.frozen?)
   end
 
+  def test_succ
+    ulid = ULID.parse('01ARZ3NDEKTSV4RRFFQ69G5FAV')
+    assert_equal(ulid.succ.to_i, ulid.to_i + 1)
+    assert_instance_of(ULID, ulid.succ)
+    assert_not_same(ulid.succ, ulid.succ)
+
+    first = ULID.parse('01BX5ZZKBKACTAV9WEVGEMMVRY')
+    assert_equal(ULID.parse('01BX5ZZKBKACTAV9WEVGEMMVRZ'), first.succ)
+    assert_equal(ULID.parse('01BX5ZZKBKACTAV9WEVGEMMVS0'), first.succ.succ)
+    assert_equal(ULID.parse('01BX5ZZKBKACTAV9WEVGEMMVS1'), first.succ.succ.succ)
+  end
+
   def test_next
     ulid = ULID.parse('01ARZ3NDEKTSV4RRFFQ69G5FAV')
     assert_equal(ulid.next.to_i, ulid.to_i + 1)

--- a/test/core/test_ulid_instance.rb
+++ b/test/core/test_ulid_instance.rb
@@ -8,6 +8,8 @@ class TestULIDInstance < Test::Unit::TestCase
     <=>
     ==
     ===
+    +
+    -
     encode
     entropy
     eql?
@@ -338,7 +340,28 @@ class TestULIDInstance < Test::Unit::TestCase
       err = assert_raises(ArgumentError) do
         ulid + evil
       end
-      assert_equal('ULID#+ takes only integer', err.message)
+      assert_equal('ULID#+ takes only integers', err.message)
+    end
+  end
+
+  def test_minus
+    ulid = ULID.parse('01ARZ3NDEKTSV4RRFFQ69G5FAV')
+    assert_equal((ulid - 42).to_i, ulid.to_i - 42)
+    assert_equal((ulid - -42).to_i, ulid.to_i + 42)
+    assert_instance_of(ULID, ulid - 42)
+    assert_not_same(ulid - 42, ulid - 42)
+    assert_raises(ArgumentError) do
+      ulid.__send__(:-)
+    end
+    assert_raises(ArgumentError) do
+      ulid.__send__(:-, 42, 6174)
+    end
+
+    [nil, '42', 42.1, BasicObject.new, Object.new, ULID.sample].each do |evil|
+      err = assert_raises(ArgumentError) do
+        ulid - evil
+      end
+      assert_equal('ULID#- takes only integers', err.message)
     end
   end
 

--- a/test/core/test_ulid_usecase.rb
+++ b/test/core/test_ulid_usecase.rb
@@ -25,6 +25,7 @@ class TestULIDUseCase < Test::Unit::TestCase
     assert_equal([begin_ulid, ulid4], exclude_end.step(3).to_a)
     assert_equal([begin_ulid], exclude_end.step(5).to_a)
 
+    omit_if(RUBY_VERSION < '3.4.0')
     assert_equal(
       [
         ULID.parse('00000000000000000000000000'),

--- a/test/core/test_ulid_usecase.rb
+++ b/test/core/test_ulid_usecase.rb
@@ -24,6 +24,15 @@ class TestULIDUseCase < Test::Unit::TestCase
     assert_equal([begin_ulid, ulid3, ulid5], exclude_end.step(2).to_a)
     assert_equal([begin_ulid, ulid4], exclude_end.step(3).to_a)
     assert_equal([begin_ulid], exclude_end.step(5).to_a)
+
+    assert_equal(
+      [
+        ULID.parse('00000000000000000000000000'),
+        ULID.parse('0000000000000000000000001A'),
+        ULID.parse('0000000000000000000000002M')
+      ],
+      (ULID.min...).step(42).take(3)
+    )
   end
 
   # https://github.com/kachick/ruby-ulid/issues/47


### PR DESCRIPTION
- **Copy ULID#next tests to ULID#succ**
- **Clarify succ, next, pred does not take arguments**
- **Implement ULID#+ to follow ruby-lang#18368**
- **Implement ULID#- to make natural API with the ULID#+ era**
- **Update README**

Resolves GH-590
