### PR TITLE
Support ULID v7

### DIFF
--- a/lib/ulid/utils.rb
+++ b/lib/ulid/utils.rb
@@ -7,20 +7,16 @@
 require('securerandom')
 
 class ULID
-  # @note I don't have confidence for the naming of `Utils`. However some standard libraries have same name.
-  #   https://github.com/ruby/webrick/blob/14612a7540fdd7373344461851c4bfff64985b3e/lib/webrick/utils.rb#L17
-  #   https://docs.ruby-lang.org/ja/latest/class/ERB=3a=3aUtil.html
-  #   https://github.com/ruby/rss/blob/af1c3c9c9630ec0a48abec48ed1ef348ba82aa13/lib/rss/utils.rb#L9
   module Utils
     # @return [Integer]
     def self.current_milliseconds
-      milliseconds_from_time(Time.now)
-    end
-
-    # @param [Time] time
-    # @return [Integer]
-    def self.milliseconds_from_time(time)
-      (time.to_r * 1000).to_i
+      # There are different recommendations for this featrure with the accuracy and other context
+      # At here, I prefer to adjust with Ruby UUID v7 imeplementation and respect monotonicity use-case
+      # https://github.com/ruby/securerandom/pull/19/files#diff-cad52e37612706fe31d85599bb8bc789e90fd382f091ed31fdd036119af3e5cdR252
+      # Other resources
+      #   - https://blog.dnsimple.com/2018/03/elapsed-time-with-ruby-the-right-way/
+      #   - https://github.com/ruby/ruby/blob/5df20ab0b49b55c9cf858879f3e6e30cc3dcd803/process.c#L8131
+      Process.clock_gettime(Process::CLOCK_REALTIME, :millisecond)
     end
 
     # @param [Time, Integer] moment
@@ -30,7 +26,7 @@ class ULID
       when Integer
         moment
       when Time
-        milliseconds_from_time(moment)
+        (moment.to_r * 1000).to_i
       else
         raise(ArgumentError, '`moment` should be a `Time` or `Integer as milliseconds`')
       end

--- a/lib/ulid/uuid.rb
+++ b/lib/ulid/uuid.rb
@@ -13,6 +13,7 @@ class ULID
     BASE_PATTERN = /\A[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}\z/i
     # Imported from https://stackoverflow.com/a/38191104/1212807, thank you!
     V4_PATTERN = /\A[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}\z/i
+    V7_PATTERN = /\A[0-9A-F]{8}-[0-9A-F]{4}-7[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}\z/i
 
     def self.parse_any_to_int(uuidish)
       encoded = String.try_convert(uuidish)
@@ -34,6 +35,18 @@ class ULID
       prefix_trimmed = encoded.delete_prefix('urn:uuid:')
       unless V4_PATTERN.match?(prefix_trimmed)
         raise(ParserError, "given `#{encoded}` does not match to `#{V4_PATTERN.inspect}`")
+      end
+
+      parse_any_to_int(encoded)
+    end
+
+    def self.parse_v7_to_int(uuid)
+      encoded = String.try_convert(uuid)
+      raise(ArgumentError, 'should pass a string for UUID parser') unless encoded
+
+      prefix_trimmed = encoded.delete_prefix('urn:uuid:')
+      unless V7_PATTERN.match?(prefix_trimmed)
+        raise(ParserError, "given `#{encoded}` does not match to `#{V7_PATTERN.inspect}`")
       end
 
       parse_any_to_int(encoded)

--- a/lib/ulid/uuid/fields.rb
+++ b/lib/ulid/uuid/fields.rb
@@ -19,13 +19,13 @@ class ULID
         end
       end
 
-      def self.forced_v4_from_octets(octets)
+      def self.forced_version_from_octets(octets, mask:)
         case octets.pack('C*').unpack('NnnnnN')
         in [Integer => time_low, Integer => time_mid, Integer => time_hi_and_version, Integer => clock_seq_hi_and_res, Integer => clk_seq_low, Integer => node]
           new(
             time_low:,
             time_mid:,
-            time_hi_and_version: (time_hi_and_version & 0x0fff) | 0x4000,
+            time_hi_and_version: (time_hi_and_version & 0x0fff) | mask,
             clock_seq_hi_and_res: (clock_seq_hi_and_res & 0x3fff) | 0x8000,
             clk_seq_low:,
             node:

--- a/scripts/generate_snapshots.rb
+++ b/scripts/generate_snapshots.rb
@@ -47,7 +47,7 @@ examples = [ancient, recently, distant_future, limit_of_toml].each_with_object({
       octets: ulid.octets,
       inspect: ulid.inspect,
       uuidish: ulid.to_uuidish,
-      uuidv4: ulid.to_uuidv4(force: true)
+      uuidv4: ulid.to_uuid_v4(force: true)
     }
   end
 end

--- a/sig/ulid.rbs
+++ b/sig/ulid.rbs
@@ -69,8 +69,6 @@ class ULID < Object
 
     def self.reasonable_entropy: -> Integer
 
-    def self.milliseconds_from_time: (Time time) -> milliseconds
-
     def self.safe_get_class_name: (untyped object) -> String
 
     def self.make_sharable_constants: (Module) -> void

--- a/sig/ulid.rbs
+++ b/sig/ulid.rbs
@@ -37,9 +37,11 @@ class ULID < Object
   module UUID
     BASE_PATTERN: Regexp
     V4_PATTERN: Regexp
+    V7_PATTERN: Regexp
 
     def self.parse_any_to_int: (String) -> Integer
     def self.parse_v4_to_int: (String) -> Integer
+    def self.parse_v7_to_int: (String) -> Integer
 
     class Fields
       attr_reader time_low: Integer
@@ -49,7 +51,7 @@ class ULID < Object
       attr_reader clk_seq_low: Integer
       attr_reader node: Integer
       def self.raw_from_octets: (octets) -> Fields
-      def self.forced_v4_from_octets: (octets) -> Fields
+      def self.forced_version_from_octets: (octets, mask: Integer) -> Fields
 
       def deconstruct: -> Array[Integer]
 
@@ -285,20 +287,23 @@ class ULID < Object
   # #=> ULID(2605-08-20 10:28:29.979 UTC: 0J7S2PFT4V2B9T8NJ2CRA1EG00)
   # ```
   #
-  # See also [ULID.from_uuidv4]
+  # See also [ULID.from_uuid_v4]
   def self.from_uuidish: (String uuidish) -> ULID
 
   # Load a UUIDv4 string with checking version and variants.
   #
   # ```ruby
-  # ULID.from_uuidv4('0983d0a2-ff15-4d83-8f37-7dd945b5aa39')
+  # ULID.from_uuid_v4('0983d0a2-ff15-4d83-8f37-7dd945b5aa39')
   # #=> ULID(2301-07-10 00:28:28.821 UTC: 09GF8A5ZRN9P1RYDVXV52VBAHS)
-  # ULID.from_uuidv4('123e4567-e89b-12d3-a456-426614174000')
+  # ULID.from_uuid_v4('123e4567-e89b-12d3-a456-426614174000')
   # #=> ULID::ParserError
   # ```
   #
   # See also [ULID.from_uuidish]
-  def self.from_uuidv4: (String uuid) -> ULID
+  def self.from_uuid_v4: (String uuid) -> ULID
+
+  # See also [ULID.from_uuid_v4]
+  def self.from_uuid_v7: (String uuid) -> ULID
 
   # Load integer as ULID
   #
@@ -646,7 +651,7 @@ class ULID < Object
   # ULID.from_uuidish(ulid.to_uuidish) #=> ULID(2023-03-07 11:48:07.469 UTC: 01GTXYCWNDKRYH14DBZ77TRSD7)
   # ```
   #
-  # See also [ULID.from_uuidish], [ULID#to_uuidv4], [ulid/spec#64](https://github.com/ulid/spec/issues/64)
+  # See also [ULID.from_uuidish], [ULID#to_uuid_v4], [ulid/spec#64](https://github.com/ulid/spec/issues/64)
   def to_uuidish: -> String
 
   # Generate a UUIDv4-like string that sets the version and variants field.\
@@ -655,18 +660,21 @@ class ULID < Object
   #
   # ```ruby
   # uuid = '0983d0a2-ff15-4d83-8f37-7dd945b5aa39'
-  # ulid = ULID.from_uuidv4(uuid)
-  # ulid.to_uuidv4 #=> 0983d0a2-ff15-4d83-8f37-7dd945b5aa39
+  # ulid = ULID.from_uuid_v4(uuid)
+  # ulid.to_uuid_v4 #=> 0983d0a2-ff15-4d83-8f37-7dd945b5aa39
   # ```
   #
   # ```ruby
   # ulid = ULID.from_uuidish('0186bbe6-72ad-9e3d-1091-abf9cfac65a7')
-  # ulid.to_uuidv4 #=> ULID::IrreversibleUUIDError
-  # ulid.to_uuidv4(force: true) #=> '0186bbe6-72ad-4e3d-9091-abf9cfac65a7'
+  # ulid.to_uuid_v4 #=> ULID::IrreversibleUUIDError
+  # ulid.to_uuid_v4(force: true) #=> '0186bbe6-72ad-4e3d-9091-abf9cfac65a7'
   # ```
   #
-  # See also [ULID.from_uuidv4], [ULID#to_uuidish], [ulid/spec#64](https://github.com/ulid/spec/issues/64)
-  def to_uuidv4: (?force: boolish) -> String
+  # See also [ULID.from_uuid_v4], [ULID#to_uuidish], [ulid/spec#64](https://github.com/ulid/spec/issues/64)
+  def to_uuid_v4: (?force: boolish) -> String
+
+  # See also [ULID.from_uuid_v7], [ULID#to_uuidish]
+  def to_uuid_v7: (?force: boolish) -> String
 
   # Returns same ID with different Ruby object.
   def dup: -> ULID

--- a/test/core/test_ulid_class.rb
+++ b/test/core/test_ulid_class.rb
@@ -59,7 +59,8 @@ class TestULIDClass < Test::Unit::TestCase
         valid_as_variant_format?
         parse_variant_format
         from_uuidish
-        from_uuidv4
+        from_uuid_v4
+        from_uuid_v7
       ].sort,
       exposed_methods.sort
     )

--- a/test/core/test_ulid_instance.rb
+++ b/test/core/test_ulid_instance.rb
@@ -31,7 +31,8 @@ class TestULIDInstance < Test::Unit::TestCase
     dup
     clone
     to_uuidish
-    to_uuidv4
+    to_uuid_v4
+    to_uuid_v7
   ].freeze
 
   ULID_RETURNING_METHODS = %i[

--- a/test/core/test_uuid.rb
+++ b/test/core/test_uuid.rb
@@ -20,7 +20,7 @@ class TestUUID < Test::Unit::TestCase
   def test_generators_return_own_instance_and_does_not_raise_in_some_basic_comparison
     ulid = ULID.sample
     [
-      Subclass.from_uuidv4(SecureRandom.uuid)
+      Subclass.from_uuid_v4(SecureRandom.uuid_v4)
     ].each do |instance|
       assert_not_instance_of(ULID, instance)
       assert_instance_of(Subclass, instance)
@@ -38,13 +38,19 @@ class TestUUID < Test::Unit::TestCase
     assert_equal(ULID.parse('09GF8A5ZRN9P1RYDVXV52VBAHS'), ULID.from_uuidish('0983d0a2-ff15-4d83-8f37-7dd945b5aa39'))
     assert_equal(ULID.parse('09GF8A5ZRN9P1RYDVXV52VBAHS'), ULID.from_uuidish('urn:uuid:0983d0a2-ff15-4d83-8f37-7dd945b5aa39'))
 
-    # UUIDv3, v5
+    # UUIDv3, v5 - Not officially supported in this gem, but I expect it also works
     assert_equal(ULID.parse('3BMYW117DD278R1D00R17X8C68'), ULID.from_uuidish('6ba7b810-9dad-11d1-80b4-00c04fd430c8'))
+
+    # UUID v7
+    assert_equal(ULID.parse('01JHQSXFTRFFHRZN260SG6P1DA'), ULID.from_uuidish('01946f9e-bf58-7be3-8fd4-4606606b05aa'))
 
     # Rough tests
     ulids = 1000.times.map do
-      ULID.from_uuidish(SecureRandom.uuid)
-    end
+      [
+        ULID.from_uuidish(SecureRandom.uuid_v4),
+        ULID.from_uuidish(SecureRandom.uuid_v7)
+      ]
+    end.flatten
     assert_true(ulids.uniq == ulids)
 
     # Ensure some invalid patterns (I'd like to add more examples)
@@ -71,37 +77,74 @@ class TestUUID < Test::Unit::TestCase
     end
   end
 
-  def test_from_uuidv4
+  def test_from_uuid_v4
     # The example value was taken from https://github.com/ahawker/ulid/tree/96bdb1daad7ce96f6db8c91ac0410b66d2e1c4c1#usage
-    assert_equal(ULID.parse('09GF8A5ZRN9P1RYDVXV52VBAHS'), ULID.from_uuidv4('0983d0a2-ff15-4d83-8f37-7dd945b5aa39'))
-    assert_equal(ULID.parse('09GF8A5ZRN9P1RYDVXV52VBAHS'), ULID.from_uuidv4('urn:uuid:0983d0a2-ff15-4d83-8f37-7dd945b5aa39'))
+    assert_equal(ULID.parse('09GF8A5ZRN9P1RYDVXV52VBAHS'), ULID.from_uuid_v4('0983d0a2-ff15-4d83-8f37-7dd945b5aa39'))
+    assert_equal(ULID.parse('09GF8A5ZRN9P1RYDVXV52VBAHS'), ULID.from_uuid_v4('urn:uuid:0983d0a2-ff15-4d83-8f37-7dd945b5aa39'))
 
     # Rough tests
     ulids = 1000.times.map do
-      ULID.from_uuidv4(SecureRandom.uuid)
+      ULID.from_uuid_v4(SecureRandom.uuid_v4)
     end
     assert_true(ulids.uniq == ulids)
 
-    # Ensure some invalid patterns (I'd like to add more examples)
+    # Ensure some invalid patterns
     [
       '6ba7b810-9dad-11d1-80b4-00c04fd430c8', # UUIDv3, v5
+      '01946f9e-bf58-7be3-8fd4-4606606b05aa', # UUIDv7
       '0983d0a2-ff15-4d83-8f37-7dd945b5aa3', # Shortage
       '0983d0a2-ff15-4d83-8f37-7dd945b5aa390', # Excess
       "0983d0a2-ff15-4d83-8f37-7dd945b5aa39\n", # Line end
       '0983d0a2-ff15-4d83-8f37--7dd945b5aa39' # `-` excess
     ].each do |invalid_uuidv4|
       assert_raises(ULID::ParserError) do
-        ULID.from_uuidv4(invalid_uuidv4)
+        ULID.from_uuid_v4(invalid_uuidv4)
       end
     end
 
     assert_raises(ArgumentError) do
-      ULID.from_uuidv4
+      ULID.from_uuid_v4
     end
 
     [nil, 42, :'0983d0a2-ff15-4d83-8f37-7dd945b5aa39', BasicObject.new, Object.new, ulids.sample].each do |evil|
       err = assert_raises(ArgumentError) do
-        ULID.from_uuidv4(evil)
+        ULID.from_uuid_v4(evil)
+      end
+      assert_equal('should pass a string for UUID parser', err.message)
+    end
+  end
+
+  def test_from_uuid_v7
+    assert_equal(ULID.parse('01JHQSXFTRFFHRZN260SG6P1DA'), ULID.from_uuid_v7('01946f9e-bf58-7be3-8fd4-4606606b05aa'))
+    assert_equal(ULID.parse('01JHQSXFTRFFHRZN260SG6P1DA'), ULID.from_uuid_v7('urn:uuid:01946f9e-bf58-7be3-8fd4-4606606b05aa'))
+
+    # Rough tests
+    ulids = 1000.times.map do
+      ULID.from_uuid_v7(SecureRandom.uuid_v7)
+    end
+    assert_true(ulids.uniq == ulids)
+
+    # Ensure some invalid patterns
+    [
+      '6ba7b810-9dad-11d1-80b4-00c04fd430c8', # UUIDv3, v5
+      '0983d0a2-ff15-4d83-8f37-7dd945b5aa39', # UUIDv4
+      '0983d0a2-ff15-4d83-8f37-7dd945b5aa3', # Shortage
+      '0983d0a2-ff15-4d83-8f37-7dd945b5aa390', # Excess
+      "0983d0a2-ff15-4d83-8f37-7dd945b5aa39\n", # Line end
+      '0983d0a2-ff15-4d83-8f37--7dd945b5aa39' # `-` excess
+    ].each do |invalid_uuidv7|
+      assert_raises(ULID::ParserError) do
+        ULID.from_uuid_v7(invalid_uuidv7)
+      end
+    end
+
+    assert_raises(ArgumentError) do
+      ULID.from_uuid_v7
+    end
+
+    [nil, 42, :'0983d0a2-ff15-4d83-8f37-7dd945b5aa39', BasicObject.new, Object.new, ulids.sample].each do |evil|
+      err = assert_raises(ArgumentError) do
+        ULID.from_uuid_v7(evil)
       end
       assert_equal('should pass a string for UUID parser', err.message)
     end
@@ -109,23 +152,37 @@ class TestUUID < Test::Unit::TestCase
 
   def test_uuid_parser_for_boundary_example
     # This behavior is same as https://github.com/ahawker/ulid/tree/96bdb1daad7ce96f6db8c91ac0410b66d2e1c4c1 on CPython 3.9.4
-    assert_equal(ULID.parse('00000000008008000000000000'), ULID.from_uuidv4('00000000-0000-4000-8000-000000000000'))
-    assert_equal(ULID.parse('7ZZZZZZZZZ9ZZVZZZZZZZZZZZZ'), ULID.from_uuidv4('ffffffff-ffff-4fff-bfff-ffffffffffff'))
+    assert_equal(ULID.parse('00000000008008000000000000'), ULID.from_uuid_v4('00000000-0000-4000-8000-000000000000'))
+    assert_equal(ULID.parse('7ZZZZZZZZZ9ZZVZZZZZZZZZZZZ'), ULID.from_uuid_v4('ffffffff-ffff-4fff-bfff-ffffffffffff'))
 
-    # Also uuidish can load as same
+    # v7
+    assert_equal(ULID.parse('0000000000E008000000000000'), ULID.from_uuid_v7('00000000-0000-7000-8000-000000000000'))
+    assert_equal(ULID.parse('7ZZZZZZZZZFZZVZZZZZZZZZZZZ'), ULID.from_uuid_v7('ffffffff-ffff-7fff-bfff-ffffffffffff'))
+
+    # Also uuidish can load as same as versioned methods
     assert_equal(ULID.parse('00000000008008000000000000'), ULID.from_uuidish('00000000-0000-4000-8000-000000000000'))
     assert_equal(ULID.parse('7ZZZZZZZZZ9ZZVZZZZZZZZZZZZ'), ULID.from_uuidish('ffffffff-ffff-4fff-bfff-ffffffffffff'))
+    assert_equal(ULID.parse('0000000000E008000000000000'), ULID.from_uuidish('00000000-0000-7000-8000-000000000000'))
+    assert_equal(ULID.parse('7ZZZZZZZZZFZZVZZZZZZZZZZZZ'), ULID.from_uuidish('ffffffff-ffff-7fff-bfff-ffffffffffff'))
 
     # Just ensuring
-    assert_not_equal(ULID.min, ULID.from_uuidv4('00000000-0000-4000-8000-000000000000'))
-    assert_not_equal(ULID.max, ULID.from_uuidv4('ffffffff-ffff-4fff-bfff-ffffffffffff'))
+    assert_not_equal(ULID.min, ULID.from_uuid_v4('00000000-0000-4000-8000-000000000000'))
+    assert_not_equal(ULID.min, ULID.from_uuid_v7('00000000-0000-7000-8000-000000000000'))
+    assert_not_equal(ULID.max, ULID.from_uuid_v4('ffffffff-ffff-4fff-bfff-ffffffffffff'))
+    assert_not_equal(ULID.max, ULID.from_uuid_v7('ffffffff-ffff-7fff-bfff-ffffffffffff'))
 
-    # Min and Max values does not have version and variants, so failed in v4 parser
+    # Min and Max values does not have version and variants, so failed in v4 and v7 parser
     assert_raises(ULID::ParserError) do
-      ULID.from_uuidv4('00000000-0000-0000-0000-000000000000')
+      ULID.from_uuid_v4('00000000-0000-0000-0000-000000000000')
     end
     assert_raises(ULID::ParserError) do
-      ULID.from_uuidv4('ffffffff-ffff-ffff-ffff-ffffffffffff')
+      ULID.from_uuid_v7('00000000-0000-0000-0000-000000000000')
+    end
+    assert_raises(ULID::ParserError) do
+      ULID.from_uuid_v4('ffffffff-ffff-ffff-ffff-ffffffffffff')
+    end
+    assert_raises(ULID::ParserError) do
+      ULID.from_uuid_v7('ffffffff-ffff-ffff-ffff-ffffffffffff')
     end
 
     # But relaxed parser parsed it with ignoring the version and variants specs
@@ -133,15 +190,15 @@ class TestUUID < Test::Unit::TestCase
     assert_equal(ULID.max, ULID.from_uuidish('ffffffff-ffff-ffff-ffff-ffffffffffff'))
   end
 
-  def test_to_uuidv4_for_typical_example
+  def test_to_uuid_v4_for_typical_example
     # The example value was taken from https://github.com/ahawker/ulid/tree/96bdb1daad7ce96f6db8c91ac0410b66d2e1c4c1#usage
     ulid = ULID.parse('09GF8A5ZRN9P1RYDVXV52VBAHS')
-    assert_equal('0983d0a2-ff15-4d83-8f37-7dd945b5aa39', ulid.to_uuidv4)
-    assert_equal('0983d0a2-ff15-4d83-8f37-7dd945b5aa39', ulid.to_uuidv4(force: false))
-    assert_equal(ulid.to_uuidv4, ulid.to_uuidv4)
-    assert_not_same(ulid.to_uuidv4, ulid.to_uuidv4)
-    assert_true(ulid.to_uuidv4.frozen?)
-    assert_equal(Encoding::US_ASCII, ulid.to_uuidv4.encoding)
+    assert_equal('0983d0a2-ff15-4d83-8f37-7dd945b5aa39', ulid.to_uuid_v4)
+    assert_equal('0983d0a2-ff15-4d83-8f37-7dd945b5aa39', ulid.to_uuid_v4(force: false))
+    assert_equal(ulid.to_uuid_v4, ulid.to_uuid_v4)
+    assert_not_same(ulid.to_uuid_v4, ulid.to_uuid_v4)
+    assert_true(ulid.to_uuid_v4.frozen?)
+    assert_equal(Encoding::US_ASCII, ulid.to_uuid_v4.encoding)
   end
 
   # @see https://github.com/kachick/ruby-ulid/issues/76 for further detail
@@ -151,41 +208,67 @@ class TestUUID < Test::Unit::TestCase
     assert_equal(ulid, ULID.from_uuidish(ulid.to_uuidish))
 
     assert_raises(ULID::ParserError) do
-      ULID.from_uuidv4(ulid.to_uuidish)
+      ULID.from_uuid_v4(ulid.to_uuidish)
     end
 
     assert_raises(ULID::IrreversibleUUIDError) do
-      ulid.to_uuidv4
+      ulid.to_uuid_v4
     end
 
-    assert_equal('4e30ea1c-6c14-423b-98a9-ecb5c3f43908', ulid.to_uuidv4(force: true))
-    assert_equal(ULID.parse('2E63N1RV0M88XSHAFCPQ1Z8E88'), ULID.from_uuidv4(ulid.to_uuidv4(force: true)))
-    assert_equal(ULID.from_uuidish(ulid.to_uuidv4(force: true)), ULID.from_uuidv4(ulid.to_uuidv4(force: true)))
+    assert_equal('4e30ea1c-6c14-423b-98a9-ecb5c3f43908', ulid.to_uuid_v4(force: true))
+    assert_equal(ULID.parse('2E63N1RV0M88XSHAFCPQ1Z8E88'), ULID.from_uuid_v4(ulid.to_uuid_v4(force: true)))
+    assert_equal(ULID.from_uuidish(ulid.to_uuid_v4(force: true)), ULID.from_uuid_v4(ulid.to_uuid_v4(force: true)))
   end
 
-  def test_to_uuidv4_for_boundary_example
-    assert_equal('00000000-0000-4000-8000-000000000000', ULID.min.to_uuidv4(force: true))
-    assert_equal('ffffffff-ffff-4fff-bfff-ffffffffffff', ULID.max.to_uuidv4(force: true))
+  def test_to_uuid_v4_for_boundary_example
+    assert_equal('00000000-0000-4000-8000-000000000000', ULID.min.to_uuid_v4(force: true))
+    assert_equal('ffffffff-ffff-4fff-bfff-ffffffffffff', ULID.max.to_uuid_v4(force: true))
 
     assert_raises(ULID::IrreversibleUUIDError) do
-      ULID.min.to_uuidv4
+      ULID.min.to_uuid_v4
     end
     assert_raises(ULID::IrreversibleUUIDError) do
-      ULID.max.to_uuidv4
+      ULID.max.to_uuid_v4
+    end
+  end
+
+  def test_to_uuid_v7_for_boundary_example
+    assert_equal('00000000-0000-7000-8000-000000000000', ULID.min.to_uuid_v7(force: true))
+    assert_equal('ffffffff-ffff-7fff-bfff-ffffffffffff', ULID.max.to_uuid_v7(force: true))
+
+    assert_raises(ULID::IrreversibleUUIDError) do
+      ULID.min.to_uuid_v7
+    end
+    assert_raises(ULID::IrreversibleUUIDError) do
+      ULID.max.to_uuid_v7
     end
   end
 
   def test_uuidv4_compatibility_with_many_random_data
     uuids = 1000.times.map do
-      SecureRandom.uuid
+      SecureRandom.uuid_v4
     end
 
     assert_true(uuids.uniq.size == 1000)
 
     ulids = uuids.map do |uuid|
-      ULID.from_uuidv4(uuid)
+      ULID.from_uuid_v4(uuid)
     end
 
-    assert_equal(uuids, ulids.map(&:to_uuidv4))
+    assert_equal(uuids, ulids.map(&:to_uuid_v4))
+  end
+
+  def test_uuidv7_compatibility_with_many_random_data
+    uuids = 1000.times.map do
+      SecureRandom.uuid_v7
+    end
+
+    assert_true(uuids.uniq.size == 1000)
+
+    ulids = uuids.map do |uuid|
+      ULID.from_uuid_v7(uuid)
+    end
+
+    assert_equal(uuids, ulids.map(&:to_uuid_v7))
   end
 end

--- a/test/many_data/test_snapshots.rb
+++ b/test/many_data/test_snapshots.rb
@@ -22,7 +22,7 @@ class TestSnapshots < Test::Unit::TestCase
       assert_equal(timestamp, ulid.timestamp)
       assert_equal(randomness, ulid.randomness)
       assert_equal(uuidish, ulid.to_uuidish)
-      assert_equal(uuidv4, ulid.to_uuidv4(force: true))
+      assert_equal(uuidv4, ulid.to_uuid_v4(force: true))
       assert_equal(to_time, ulid.to_time)
       assert_equal(octets, ulid.octets)
     else


### PR DESCRIPTION
- **Prefer Process.clock_gettime rather than Time.now to get current time**
- **Implement UUID v7 helpers**

Resolves GH-540

Closes GH-533 since clarified maintenance mode
