### PR TITLE
Bring back Ractor#take in testing code

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -203,6 +203,7 @@ Style/DisableCopsWithinSourceCodeDirective:
   Enabled: true
   Exclude:
     - Rakefile
+    - 'test/**/*'
 
 Style/DocumentDynamicEvalDefinition:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -203,7 +203,6 @@ Style/DisableCopsWithinSourceCodeDirective:
   Enabled: true
   Exclude:
     - Rakefile
-    - 'test/**/*'
 
 Style/DocumentDynamicEvalDefinition:
   Enabled: false

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -87,31 +87,6 @@ end
 # We are currently only using Ractor#take in testing code, so we reluctantly added a monkey patch.
 if RUBY_VERSION >= '3.5'
   class Ractor
-    def initialize
-      @yield_ractor = Ractor.new do
-        @takers = []
-        while (tag, msg = Ractor.receive)
-          case tag
-          when :register
-            @takers << msg
-          when :unregister
-            @takers.delete(msg)
-          when :yield
-            @takers.pop << msg
-          end
-        end
-      end
-    end
-
-    def self.yield(obj)
-      @yield_ractor << [:yield, obj] # rubocop:disable ThreadSafety/ClassInstanceVariable
-    end
-
-    def take
-      @yield_ractor << [:register, port = Ractor::Port.new]
-      port.receive
-    ensure
-      @yield_ractor << [:unregister, port]
-    end
+    alias_method :take, :value
   end
 end


### PR DESCRIPTION
Fixes #748

I don't have confidence about this change. Dropping ractor support in this gem is a way.